### PR TITLE
Fix SSR registration form and improve email confirmation UX

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,12 @@ Organized by domain. Each folder contains specs, designs, and decisions for that
 | [Database & EF Core](infrastructure/database.md) | PostgreSQL setup, AppDbContext, migrations, schema, conventions |
 | [Logging & Observability](infrastructure/logging.md) | Serilog configuration, Seq, sinks, log levels |
 
+## Design System Documents
+
+| Document | Description |
+|----------|-------------|
+| [Blazor SSR Forms](design-system/blazor-ssr-forms.md) | SSR form patterns, the conditional `<EditForm>` gotcha, and multi-step wizard solution |
+
 ## Architecture Decision Records
 
 | ADR | Domain | Title |

--- a/docs/design-system/blazor-ssr-forms.md
+++ b/docs/design-system/blazor-ssr-forms.md
@@ -1,0 +1,158 @@
+# Blazor SSR Forms — Patterns and Gotchas
+
+Guidance for building forms in Blazor Static Server-Side Rendering (SSR) mode. Static SSR is the default rendering mode in .NET 8/9 Blazor. These patterns apply to any page that does **not** use `@rendermode InteractiveServer`.
+
+---
+
+## Gotcha: Conditional `<EditForm>` Causes "No Form Found" Error
+
+### Symptom
+
+Submitting a form raises:
+
+```
+Cannot submit the form 'X' because no form on the page currently has that name.
+```
+
+### Cause
+
+Blazor SSR requires a form to exist in the render tree **at the moment the POST is processed**. When you use `@if` / `else` to toggle between two separate `<EditForm>` components, the server handles the POST by creating a **fresh component instance** with **default state**. The condition therefore evaluates the same way it did on the very first render — not the way it was when the user clicked submit — and the expected form is absent from the tree.
+
+This is a **known framework limitation**, confirmed by the ASP.NET Core team as "by design."
+
+References:
+- [dotnet/aspnetcore#55808](https://github.com/dotnet/aspnetcore/issues/55808)
+- [dotnet/aspnetcore#54854](https://github.com/dotnet/aspnetcore/issues/54854)
+- [dotnet/aspnetcore#52360](https://github.com/dotnet/aspnetcore/issues/52360)
+
+### Where We Hit This
+
+The `/Account/Register` page had a two-step invite-code wizard:
+
+- Step 1 — validate invite code (`FormName="validate-code"`)
+- Step 2 — fill in registration details (`FormName="register"`)
+
+Using `@if (!_codeValidated)` / `else` to switch between two separate `<EditForm>` components triggered the error on step 2 submission.
+
+---
+
+## Solution: Single `<EditForm>` with Conditional Content
+
+Keep **one** `<EditForm>` permanently in the render tree. Toggle the *content inside* the form, not the form wrapper itself. Use a hidden `Step` field to carry the current step across the POST round-trip.
+
+```razor
+<EditForm Model="Input" method="post" OnValidSubmit="OnSubmit" FormName="register">
+    <DataAnnotationsValidator />
+
+    {{!-- Hidden field preserves step across the POST round-trip --}}
+    <input type="hidden" name="Input.Step" value="@Input.Step" />
+
+    @if (Input.Step == 1)
+    {
+        <FormInput @bind-Value="Input.InviteCode" Label="Invite Code" />
+        <Button type="submit">Verify Code</Button>
+    }
+    else
+    {
+        <FormInput @bind-Value="Input.Email" Label="Email" />
+        <FormInput @bind-Value="Input.Password" Label="Password" InputType="password" />
+        <Button type="submit">Create Account</Button>
+    }
+</EditForm>
+```
+
+Route in the handler based on `Input.Step`:
+
+```csharp
+[SupplyParameterFromForm]
+private InputModel Input { get; set; } = new();
+
+public async Task<IActionResult> OnSubmit(EditContext editContext)
+{
+    if (Input.Step == 1)
+        return await HandleStep1Async();
+
+    return await HandleStep2Async();
+}
+```
+
+The model carries the step:
+
+```csharp
+public class InputModel
+{
+    public int Step { get; set; } = 1;
+
+    // Step 1
+    public string InviteCode { get; set; } = string.Empty;
+
+    // Step 2
+    [Required, EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    public string Password { get; set; } = string.Empty;
+}
+```
+
+---
+
+## Official Workarounds from the ASP.NET Core Team
+
+Three patterns are recognized. Choose based on complexity and accessibility requirements.
+
+| Approach | When to Use |
+|----------|-------------|
+| **Single form with conditional content** (recommended) | Multi-step wizards, toggling between form modes |
+| **CSS hiding** | Simple show/hide with no logic branching |
+| **Structural rearrangement** | When form wrappers must stay separate for other reasons |
+
+### Option 1 — Single Form with Conditional Content (Recommended)
+
+Described above. One `<EditForm>`, always rendered. Hidden `Step` field drives branching.
+
+### Option 2 — CSS Hiding
+
+Render all forms simultaneously, hide inactive ones with `display:none`. Both forms are always in the DOM and the render tree.
+
+```razor
+<EditForm Model="Step1Input" method="post" OnValidSubmit="OnStep1Submit" FormName="step1"
+          style="@(CurrentStep == 1 ? "" : "display:none")">
+    ...
+</EditForm>
+
+<EditForm Model="Step2Input" method="post" OnValidSubmit="OnStep2Submit" FormName="step2"
+          style="@(CurrentStep == 2 ? "" : "display:none")">
+    ...
+</EditForm>
+```
+
+Drawback: hidden form fields are still submitted if the browser serializes the wrong form. Use only when forms have distinct `FormName` values and the payload is unambiguous.
+
+### Option 3 — Structural Rearrangement
+
+Move the `<EditForm>` tags outside the conditional block; put only the field content inside. Works when the surrounding markup allows it.
+
+```razor
+<EditForm Model="Input" method="post" OnValidSubmit="OnSubmit" FormName="wizard">
+    @if (Input.Step == 1)
+    {
+        <!-- Step 1 content -->
+    }
+    @if (Input.Step == 2)
+    {
+        <!-- Step 2 content -->
+    }
+</EditForm>
+```
+
+This is functionally equivalent to Option 1; the distinction is stylistic.
+
+---
+
+## General Blazor SSR Form Rules
+
+- Every interactive form handler must use `[SupplyParameterFromForm]` on the bound model property.
+- `FormName` must be unique per page if multiple `<EditForm>` components are rendered simultaneously.
+- State is **not** preserved between requests in SSR mode — any field not submitted as a form value is lost. Use hidden fields or the `Step` pattern to thread state across POST round-trips.
+- `@rendermode InteractiveServer` bypasses all of these constraints, but adds a SignalR circuit. Prefer SSR for auth flows and public-facing forms.

--- a/src/Nutrir.Web/Components/Account/Pages/ConfirmEmail.razor
+++ b/src/Nutrir.Web/Components/Account/Pages/ConfirmEmail.razor
@@ -14,6 +14,10 @@
 <h2 class="auth-status-title">Confirm email</h2>
 <StatusMessage Message="@statusMessage" />
 
+<div class="text-center mt-6">
+    <a href="Account/Login" class="text-sm">Continue to sign in</a>
+</div>
+
 @code {
     private string? statusMessage;
 

--- a/src/Nutrir.Web/Components/Account/Pages/Register.razor
+++ b/src/Nutrir.Web/Components/Account/Pages/Register.razor
@@ -25,47 +25,43 @@
 
 <StatusMessage Message="@Message" />
 
-@if (!_codeValidated)
-{
-    <p class="text-sm text-muted mb-4">Enter your invite code to get started.</p>
+<EditForm Model="Input" method="post" OnSubmit="OnSubmit" FormName="register">
 
-    <EditForm Model="CodeInput" method="post" OnValidSubmit="ValidateInviteCode" FormName="validate-code">
-        <DataAnnotationsValidator />
-        <ValidationSummary class="form-error" role="alert" />
+    <input type="hidden" name="Input.Step" value="@Input.Step" />
+    <input type="hidden" name="Input.InviteCode" value="@Input.InviteCode" />
+
+    @if (Input.Step == 1)
+    {
+        <p class="text-sm text-muted mb-4">Enter your invite code to get started.</p>
+
         @if (_codeError is not null)
         {
             <div class="status-message status-message-error" role="alert">@_codeError</div>
         }
         <div class="flex flex-col gap-4">
             <div class="form-group">
-                <label for="CodeInput.Code" class="form-label">Invite Code</label>
-                <InputText @bind-Value="CodeInput.Code" id="CodeInput.Code" class="form-input" autocomplete="off" aria-required="true" placeholder="ABC-1234" />
-                <ValidationMessage For="() => CodeInput.Code" class="form-error" />
+                <label for="Input.CodeEntry" class="form-label">Invite Code</label>
+                <InputText @bind-Value="Input.CodeEntry" id="Input.CodeEntry" class="form-input" autocomplete="off" aria-required="true" placeholder="ABC-1234" />
+                <ValidationMessage For="() => Input.CodeEntry" class="form-error" />
             </div>
             <button type="submit" class="btn btn-primary btn-lg btn-block">Validate Code</button>
         </div>
-    </EditForm>
 
-    <div class="flex flex-col gap-2 mt-6 text-center">
-        <span class="text-sm text-muted">
-            Already have an account?
-            <a href="Account/Login">Sign in</a>
-        </span>
-    </div>
-}
-else
-{
-    <div class="flex items-center gap-2 mb-4">
-        <span class="text-sm text-muted">Registering as:</span>
-        <span class="badge badge-primary">@_targetRole</span>
-    </div>
+        <div class="flex flex-col gap-2 mt-6 text-center">
+            <span class="text-sm text-muted">
+                Already have an account?
+                <a href="Account/Login">Sign in</a>
+            </span>
+        </div>
+    }
+    else
+    {
+        <div class="flex items-center gap-2 mb-4">
+            <span class="text-sm text-muted">Registering as:</span>
+            <span class="badge badge-primary">@_targetRole</span>
+        </div>
 
-    <EditForm Model="Input" method="post" OnValidSubmit="RegisterUser" FormName="register">
-        <DataAnnotationsValidator />
         <ValidationSummary class="form-error" role="alert" />
-
-        <input type="hidden" name="Input.InviteCode" value="@Input.InviteCode" />
-        <input type="hidden" name="Input.TargetRole" value="@_targetRole" />
 
         <div class="flex flex-col gap-4">
             <div class="form-group">
@@ -95,30 +91,26 @@ else
             </div>
             <button type="submit" class="btn btn-primary btn-lg btn-block">Register</button>
         </div>
-    </EditForm>
 
-    <div class="divider-text mt-6 mb-6">or continue with</div>
+        <div class="divider-text mt-6 mb-6">or continue with</div>
 
-    <ExternalLoginPicker />
+        <ExternalLoginPicker />
 
-    <div class="flex flex-col gap-2 mt-6 text-center">
-        <span class="text-sm text-muted">
-            Already have an account?
-            <a href="Account/Login">Sign in</a>
-        </span>
-    </div>
-}
+        <div class="flex flex-col gap-2 mt-6 text-center">
+            <span class="text-sm text-muted">
+                Already have an account?
+                <a href="Account/Login">Sign in</a>
+            </span>
+        </div>
+    }
+</EditForm>
 
 @code {
     private IEnumerable<IdentityError>? identityErrors;
-    private bool _codeValidated;
     private string? _targetRole;
     private string? _codeError;
 
-    [SupplyParameterFromForm(FormName = "validate-code")]
-    private CodeInputModel CodeInput { get; set; } = new();
-
-    [SupplyParameterFromForm(FormName = "register")]
+    [SupplyParameterFromForm]
     private InputModel Input { get; set; } = new();
 
     [SupplyParameterFromQuery]
@@ -126,22 +118,39 @@ else
 
     private string? Message => identityErrors is null ? null : $"Error: {string.Join(", ", identityErrors.Select(error => error.Description))}";
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        // When the "register" form POSTs, the component re-creates with _codeValidated = false.
-        // Restore step-2 state from the posted InviteCode so the form exists in the render tree.
-        if (!string.IsNullOrEmpty(Input.InviteCode))
+        // When step 2 POSTs, restore the target role from the invite code.
+        if (Input.Step == 2 && !string.IsNullOrEmpty(Input.InviteCode))
         {
-            _codeValidated = true;
-            _targetRole = Input.TargetRole;
+            var result = await InviteCodeService.ValidateAsync(Input.InviteCode);
+            _targetRole = result.IsValid ? result.TargetRole : null;
         }
     }
 
-    public async Task ValidateInviteCode(EditContext editContext)
+    public async Task OnSubmit(EditContext editContext)
+    {
+        if (Input.Step == 1)
+        {
+            await ValidateInviteCode();
+        }
+        else
+        {
+            await RegisterUser();
+        }
+    }
+
+    private async Task ValidateInviteCode()
     {
         _codeError = null;
 
-        var result = await InviteCodeService.ValidateAsync(CodeInput.Code);
+        if (string.IsNullOrWhiteSpace(Input.CodeEntry))
+        {
+            _codeError = "An invite code is required to register.";
+            return;
+        }
+
+        var result = await InviteCodeService.ValidateAsync(Input.CodeEntry);
 
         if (!result.IsValid)
         {
@@ -155,20 +164,19 @@ else
             return;
         }
 
-        _codeValidated = true;
+        Input.Step = 2;
+        Input.InviteCode = Input.CodeEntry;
         _targetRole = result.TargetRole;
-        Input.InviteCode = CodeInput.Code;
-        Input.TargetRole = result.TargetRole ?? "";
     }
 
-    public async Task RegisterUser(EditContext editContext)
+    private async Task RegisterUser()
     {
         // Re-validate the invite code to prevent tampering
         var codeResult = await InviteCodeService.ValidateAsync(Input.InviteCode);
         if (!codeResult.IsValid)
         {
             identityErrors = new[] { new IdentityError { Description = "The invite code is no longer valid." } };
-            _codeValidated = false;
+            Input.Step = 1;
             return;
         }
 
@@ -185,7 +193,6 @@ else
         if (!result.Succeeded)
         {
             identityErrors = result.Errors;
-            _codeValidated = true;
             _targetRole = codeResult.TargetRole;
             return;
         }
@@ -244,15 +251,14 @@ else
         return (IUserEmailStore<ApplicationUser>)UserStore;
     }
 
-    private sealed class CodeInputModel
-    {
-        [Required(ErrorMessage = "An invite code is required to register.")]
-        [Display(Name = "Invite Code")]
-        public string Code { get; set; } = "";
-    }
-
     private sealed class InputModel
     {
+        public int Step { get; set; } = 1;
+
+        public string CodeEntry { get; set; } = "";
+
+        public string InviteCode { get; set; } = "";
+
         [Required]
         [Display(Name = "First Name")]
         public string FirstName { get; set; } = "";
@@ -276,9 +282,5 @@ else
         [Display(Name = "Confirm password")]
         [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
         public string ConfirmPassword { get; set; } = "";
-
-        public string InviteCode { get; set; } = "";
-
-        public string TargetRole { get; set; } = "";
     }
 }


### PR DESCRIPTION
## Summary
- Fix "Cannot submit the form 'register'" error on the invite-code registration wizard by using a single `<EditForm>` with a hidden `Step` field instead of conditionally rendered forms (known Blazor SSR limitation)
- Add "Continue to sign in" link on the `/Account/ConfirmEmail` page
- Document the Blazor SSR form gotcha in `docs/design-system/blazor-ssr-forms.md`

## Test plan
- [ ] Navigate to `/Account/Register`, enter a valid invite code, complete registration — no form submission errors
- [ ] After email confirmation, verify the "Continue to sign in" link appears on `/Account/ConfirmEmail`
- [ ] Enter an invalid/expired/used invite code and verify appropriate error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)