### PR TITLE
Link sidebar avatar to Account/Manage page (#21)

### DIFF
--- a/src/Nutrir.Web/Components/Layout/IconRailSidebar.razor
+++ b/src/Nutrir.Web/Components/Layout/IconRailSidebar.razor
@@ -85,9 +85,9 @@
                         </svg>
                     </button>
                 </form>
-                <div class="rail-avatar" title="@context.User.Identity?.Name">
+                <NavLink class="rail-avatar" href="Account/Manage" title="@context.User.Identity?.Name">
                     @(context.User.Identity?.Name?.Substring(0, 1).ToUpper())
-                </div>
+                </NavLink>
             </Authorized>
             <NotAuthorized>
                 <NavLink class="rail-item" href="Account/Login" title="Login">

--- a/src/Nutrir.Web/wwwroot/css/layout.css
+++ b/src/Nutrir.Web/wwwroot/css/layout.css
@@ -137,6 +137,7 @@
   font-weight: 600;
   font-family: var(--font-display);
   cursor: pointer;
+  text-decoration: none;
   transition: background var(--duration-fast) var(--ease-default);
 }
 


### PR DESCRIPTION
## Summary
- Changed the sidebar avatar from a static `<div>` to a `<NavLink>` that navigates to `Account/Manage`
- Added `text-decoration: none` to `.rail-avatar` CSS to prevent default link underline styling

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)