### PR TITLE
feat: widen client pages and auto-format phone numbers

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
@@ -66,7 +66,7 @@
                         <FormInput Id="phone"
                                    Type="tel"
                                    Value="@_model.Phone"
-                                   ValueChanged="@(v => _model.Phone = v)"
+                                   ValueChanged="OnPhoneChanged"
                                    Placeholder="(555) 123-4567" />
                     </FormGroup>
                 </div>
@@ -133,6 +133,11 @@
         _editContext = new EditContext(_model);
     }
 
+    private void OnPhoneChanged(string value)
+    {
+        _model.Phone = PhoneFormatter.Format(value);
+    }
+
     private void OnConsentChanged(bool value)
     {
         _model.ConsentGiven = value;
@@ -159,7 +164,7 @@
                 FirstName: _model.FirstName!,
                 LastName: _model.LastName!,
                 Email: string.IsNullOrWhiteSpace(_model.Email) ? null : _model.Email,
-                Phone: string.IsNullOrWhiteSpace(_model.Phone) ? null : _model.Phone,
+                Phone: string.IsNullOrWhiteSpace(_model.Phone) ? null : PhoneFormatter.ToDigits(_model.Phone),
                 DateOfBirth: dob,
                 PrimaryNutritionistId: userId,
                 PrimaryNutritionistName: null,

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor.css
@@ -1,6 +1,6 @@
 /* ── Page Container ───────────────────────────────────── */
 .form-page {
-    max-width: 720px;
+    max-width: 960px;
     padding: var(--space-8);
 }
 

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientDetail.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientDetail.razor
@@ -55,7 +55,7 @@
                                 {
                                     <span class="contact-item">
                                         <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2.5 1.5h3l1.5 4-2 1.5a9 9 0 0 0 4 4l1.5-2 4 1.5v3c0 .6-.4 1-1 1C6.5 14.5 1.5 9.5 1.5 3c0-.6.4-1 1-1Z"/></svg>
-                                        @_client.Phone
+                                        @PhoneFormatter.Format(_client.Phone)
                                     </span>
                                 }
                             </div>

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientDetail.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientDetail.razor.css
@@ -1,6 +1,6 @@
 /* ── Page Container ──────────────────────────────────── */
 .client-detail-page {
-    max-width: 720px;
+    max-width: 960px;
     margin: 0 auto;
     padding: var(--space-8);
     display: flex;

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
@@ -88,7 +88,7 @@
                             <FormInput Id="phone"
                                        Type="tel"
                                        Value="@_model.Phone"
-                                       ValueChanged="@(v => _model.Phone = v)"
+                                       ValueChanged="OnPhoneChanged"
                                        Placeholder="(555) 123-4567" />
                         </FormGroup>
                     </div>
@@ -173,7 +173,7 @@
                 FirstName = _client.FirstName,
                 LastName = _client.LastName,
                 Email = _client.Email,
-                Phone = _client.Phone,
+                Phone = PhoneFormatter.Format(_client.Phone),
                 DateOfBirth = _client.DateOfBirth?.ToString("yyyy-MM-dd"),
                 PrimaryNutritionistId = _client.PrimaryNutritionistId,
                 ConsentGiven = _client.ConsentGiven,
@@ -183,6 +183,11 @@
         }
 
         _isLoading = false;
+    }
+
+    private void OnPhoneChanged(string value)
+    {
+        _model.Phone = PhoneFormatter.Format(value);
     }
 
     private void OnConsentChanged(bool value)
@@ -229,7 +234,7 @@
                 FirstName: _model.FirstName!,
                 LastName: _model.LastName!,
                 Email: string.IsNullOrWhiteSpace(_model.Email) ? null : _model.Email,
-                Phone: string.IsNullOrWhiteSpace(_model.Phone) ? null : _model.Phone,
+                Phone: string.IsNullOrWhiteSpace(_model.Phone) ? null : PhoneFormatter.ToDigits(_model.Phone),
                 DateOfBirth: dob,
                 PrimaryNutritionistId: _model.PrimaryNutritionistId ?? string.Empty,
                 PrimaryNutritionistName: null,

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor.css
@@ -1,6 +1,6 @@
 /* ── Page Container ───────────────────────────────────── */
 .form-page {
-    max-width: 720px;
+    max-width: 960px;
     padding: var(--space-8);
 }
 

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientList.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientList.razor
@@ -104,7 +104,7 @@
                                     </div>
                                 </div>
                             </td>
-                            <td class="col-phone cell-phone">@(client.Phone ?? "—")</td>
+                            <td class="col-phone cell-phone">@(PhoneFormatter.FormatOrNull(client.Phone) ?? "—")</td>
                             <td class="col-nutritionist cell-nutritionist">@(client.PrimaryNutritionistName ?? client.PrimaryNutritionistId)</td>
                             <td class="col-consent cell-consent">
                                 @if (client.ConsentGiven)

--- a/src/Nutrir.Web/Components/UI/PhoneFormatter.cs
+++ b/src/Nutrir.Web/Components/UI/PhoneFormatter.cs
@@ -1,0 +1,40 @@
+namespace Nutrir.Web.Components.UI;
+
+public static class PhoneFormatter
+{
+    /// <summary>
+    /// Strips all non-digit characters from the input.
+    /// </summary>
+    public static string ToDigits(string? input)
+    {
+        if (string.IsNullOrEmpty(input)) return string.Empty;
+        return new string(input.Where(char.IsDigit).ToArray());
+    }
+
+    /// <summary>
+    /// Formats a digit string as (XXX) XXX-XXXX.
+    /// Handles partial input gracefully.
+    /// </summary>
+    public static string Format(string? input)
+    {
+        var digits = ToDigits(input);
+        if (digits.Length == 0) return string.Empty;
+
+        return digits.Length switch
+        {
+            <= 3 => $"({digits}",
+            <= 6 => $"({digits[..3]}) {digits[3..]}",
+            <= 10 => $"({digits[..3]}) {digits[3..6]}-{digits[6..]}",
+            _ => $"({digits[..3]}) {digits[3..6]}-{digits[6..10]}"
+        };
+    }
+
+    /// <summary>
+    /// Formats for display. Returns null if input is empty.
+    /// </summary>
+    public static string? FormatOrNull(string? input)
+    {
+        var formatted = Format(input);
+        return string.IsNullOrEmpty(formatted) ? null : formatted;
+    }
+}


### PR DESCRIPTION
## Summary
- Widen client detail/create/edit page containers from 720px to 960px for better use of screen space on large monitors
- Add phone number auto-formatting as `(XXX) XXX-XXXX` on client create/edit forms with digits-only storage
- Display formatted phone numbers on client detail and list pages

Closes #25, closes #22

## Test plan
- [ ] Verify client detail/create/edit pages use wider container on 1440px+ screens
- [ ] Verify pages still look good on ~1024px and remain responsive on mobile
- [ ] Type digits into phone field on create/edit — confirm auto-formatting to `(XXX) XXX-XXXX`
- [ ] Verify backspace works through formatting characters
- [ ] Edit an existing client — confirm phone loads formatted
- [ ] Save a client and verify digits-only stored in DB
- [ ] Check client list and detail pages display formatted phone numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)