### PR TITLE
feat: add autocomplete nutritionist picker to client forms (#27)

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
@@ -10,6 +10,7 @@
 @using Nutrir.Web.Components.UI
 @attribute [Authorize(Roles = "Admin,Nutritionist,Assistant")]
 @inject IClientService ClientService
+@inject IUserManagementService UserManagementService
 @inject NavigationManager NavigationManager
 
 <PageTitle>New Client — Nutrir</PageTitle>
@@ -78,6 +79,16 @@
                                    Value="@_model.DateOfBirth"
                                    ValueChanged="@(v => _model.DateOfBirth = v)" />
                     </FormGroup>
+
+                    <FormGroup Label="Primary Nutritionist" Id="nutritionist" Error="@GetFieldError(nameof(_model.PrimaryNutritionistId))">
+                        <Autocomplete Id="nutritionist"
+                                      Options="@_nutritionistOptions"
+                                      Value="@_model.PrimaryNutritionistId"
+                                      ValueChanged="@(v => _model.PrimaryNutritionistId = v)"
+                                      DisplayText="@_nutritionistDisplayText"
+                                      DisplayTextChanged="@(v => _nutritionistDisplayText = v)"
+                                      Placeholder="Search for a nutritionist..." />
+                    </FormGroup>
                 </div>
 
                 <FormGroup Label="Notes" Id="notes">
@@ -127,10 +138,29 @@
     private EditContext? _editContext;
     private bool _isSubmitting;
     private string? _errorMessage;
+    private IReadOnlyList<Autocomplete.AutocompleteOption> _nutritionistOptions = [];
+    private string? _nutritionistDisplayText;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         _editContext = new EditContext(_model);
+
+        var nutritionists = await UserManagementService.GetUsersAsync(
+            roleFilter: "Nutritionist", isActiveFilter: true);
+
+        _nutritionistOptions = nutritionists
+            .Select(n => new Autocomplete.AutocompleteOption(n.Id, n.DisplayName))
+            .ToList();
+
+        // Default to the current logged-in user if they are a nutritionist
+        var authState = await AuthState;
+        var userId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var currentUserOption = _nutritionistOptions.FirstOrDefault(o => o.Value == userId);
+        if (currentUserOption is not null)
+        {
+            _model.PrimaryNutritionistId = currentUserOption.Value;
+            _nutritionistDisplayText = currentUserOption.Text;
+        }
     }
 
     private void OnPhoneChanged(string value)
@@ -166,7 +196,7 @@
                 Email: string.IsNullOrWhiteSpace(_model.Email) ? null : _model.Email,
                 Phone: string.IsNullOrWhiteSpace(_model.Phone) ? null : PhoneFormatter.ToDigits(_model.Phone),
                 DateOfBirth: dob,
-                PrimaryNutritionistId: userId,
+                PrimaryNutritionistId: _model.PrimaryNutritionistId!,
                 PrimaryNutritionistName: null,
                 ConsentGiven: _model.ConsentGiven,
                 ConsentTimestamp: _model.ConsentGiven ? DateTime.UtcNow : null,
@@ -212,6 +242,9 @@
         public string? Phone { get; set; }
 
         public string? DateOfBirth { get; set; }
+
+        [Required(ErrorMessage = "A primary nutritionist is required.")]
+        public string? PrimaryNutritionistId { get; set; }
 
         public bool ConsentGiven { get; set; }
 

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
@@ -10,6 +10,7 @@
 @using Nutrir.Web.Components.UI
 @attribute [Authorize(Roles = "Admin,Nutritionist,Assistant")]
 @inject IClientService ClientService
+@inject IUserManagementService UserManagementService
 @inject NavigationManager NavigationManager
 
 <PageTitle>Edit Client — Nutrir</PageTitle>
@@ -101,11 +102,14 @@
                                        ValueChanged="@(v => _model.DateOfBirth = v)" />
                         </FormGroup>
 
-                        <FormGroup Label="Primary Nutritionist ID" Id="nutritionistId">
-                            <FormInput Id="nutritionistId"
-                                       Value="@_model.PrimaryNutritionistId"
-                                       ValueChanged="@(v => _model.PrimaryNutritionistId = v)"
-                                       Placeholder="User ID of the nutritionist" />
+                        <FormGroup Label="Primary Nutritionist" Id="nutritionist">
+                            <Autocomplete Id="nutritionist"
+                                          Options="@_nutritionistOptions"
+                                          Value="@_model.PrimaryNutritionistId"
+                                          ValueChanged="@(v => _model.PrimaryNutritionistId = v)"
+                                          DisplayText="@_nutritionistDisplayText"
+                                          DisplayTextChanged="@(v => _nutritionistDisplayText = v)"
+                                          Placeholder="Search for a nutritionist..." />
                         </FormGroup>
                     </div>
 
@@ -161,6 +165,8 @@
     private bool _isLoading = true;
     private bool _isSubmitting;
     private string? _errorMessage;
+    private IReadOnlyList<Autocomplete.AutocompleteOption> _nutritionistOptions = [];
+    private string? _nutritionistDisplayText;
 
     protected override async Task OnInitializedAsync()
     {
@@ -180,6 +186,19 @@
                 Notes = _client.Notes
             };
             _editContext = new EditContext(_model);
+
+            var nutritionists = await UserManagementService.GetUsersAsync(
+                roleFilter: "Nutritionist", isActiveFilter: true);
+
+            _nutritionistOptions = nutritionists
+                .Select(n => new Autocomplete.AutocompleteOption(n.Id, n.DisplayName))
+                .ToList();
+
+            // Pre-populate display text from loaded nutritionist list or from the client record
+            var currentNutritionist = _nutritionistOptions.FirstOrDefault(
+                o => o.Value == _client.PrimaryNutritionistId);
+            _nutritionistDisplayText = currentNutritionist?.Text
+                ?? _client.PrimaryNutritionistName;
         }
 
         _isLoading = false;

--- a/src/Nutrir.Web/Components/UI/Autocomplete.razor
+++ b/src/Nutrir.Web/Components/UI/Autocomplete.razor
@@ -1,0 +1,189 @@
+@using Microsoft.AspNetCore.Components.Web
+
+<div class="autocomplete-wrapper" @onfocusout="HandleFocusOut">
+    <input id="@Id"
+           type="text"
+           class="form-input"
+           value="@_searchText"
+           placeholder="@Placeholder"
+           autocomplete="off"
+           role="combobox"
+           aria-expanded="@_isOpen.ToString().ToLower()"
+           aria-autocomplete="list"
+           aria-controls="@($"{Id}-listbox")"
+           @oninput="HandleInput"
+           @onfocusin="HandleFocusIn"
+           @onkeydown="HandleKeyDown"
+           @attributes="AdditionalAttributes" />
+
+    @if (_isOpen && _filteredOptions.Count > 0)
+    {
+        <ul class="autocomplete-dropdown" id="@($"{Id}-listbox")" role="listbox" aria-label="@Placeholder">
+            @for (var i = 0; i < _filteredOptions.Count; i++)
+            {
+                var option = _filteredOptions[i];
+                var index = i;
+                var isSelected = option.Value == Value;
+                var isFocused = index == _highlightedIndex;
+                <li class="autocomplete-option @(isSelected ? "selected" : "") @(isFocused ? "focused" : "")"
+                    role="option"
+                    aria-selected="@(isSelected ? "true" : "false")"
+                    @onmousedown="() => SelectOption(option)"
+                    @onmousedown:preventDefault>
+                    @option.Text
+                </li>
+            }
+        </ul>
+    }
+</div>
+
+@code {
+    [Parameter] public string? Id { get; set; }
+    [Parameter] public IReadOnlyList<AutocompleteOption> Options { get; set; } = [];
+    [Parameter] public string? Value { get; set; }
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+    [Parameter] public string? DisplayText { get; set; }
+    [Parameter] public EventCallback<string> DisplayTextChanged { get; set; }
+    [Parameter] public string? Placeholder { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string _searchText = string.Empty;
+    private bool _isOpen;
+    private bool _autoSelected;
+    private int _highlightedIndex = -1;
+    private List<AutocompleteOption> _filteredOptions = [];
+
+    protected override async Task OnParametersSetAsync()
+    {
+        // Sync display text from parent when not actively searching
+        if (!_isOpen && !string.IsNullOrEmpty(DisplayText))
+        {
+            _searchText = DisplayText;
+        }
+        else if (!_isOpen && !string.IsNullOrEmpty(Value))
+        {
+            // Fall back to finding display text from options
+            var match = Options.FirstOrDefault(o => o.Value == Value);
+            if (match is not null)
+            {
+                _searchText = match.Text;
+            }
+        }
+
+        // Auto-select if only one option (once only)
+        if (Options.Count == 1 && string.IsNullOrEmpty(Value) && !_autoSelected)
+        {
+            _autoSelected = true;
+            await SelectOption(Options[0]);
+        }
+    }
+
+    private void HandleInput(ChangeEventArgs e)
+    {
+        _searchText = e.Value?.ToString() ?? string.Empty;
+        _isOpen = true;
+        _highlightedIndex = -1;
+        FilterOptions();
+    }
+
+    private void HandleFocusIn()
+    {
+        _isOpen = true;
+        _highlightedIndex = -1;
+        FilterOptions();
+    }
+
+    private async Task HandleFocusOut()
+    {
+        // Small delay to allow click on dropdown item to register
+        await Task.Delay(200);
+        _isOpen = false;
+        _highlightedIndex = -1;
+
+        if (string.IsNullOrEmpty(_searchText))
+        {
+            // Empty text on blur clears the selection
+            await ValueChanged.InvokeAsync(string.Empty);
+            await DisplayTextChanged.InvokeAsync(string.Empty);
+        }
+        else
+        {
+            // If the current text doesn't match a selected option, revert
+            var match = Options.FirstOrDefault(o =>
+                o.Text.Equals(_searchText, StringComparison.OrdinalIgnoreCase));
+            if (match is null && !string.IsNullOrEmpty(Value))
+            {
+                // Text was changed but doesn't match any option - revert to selected display
+                var selected = Options.FirstOrDefault(o => o.Value == Value);
+                _searchText = selected?.Text ?? string.Empty;
+            }
+        }
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (!_isOpen && e.Key is "ArrowDown" or "ArrowUp")
+        {
+            _isOpen = true;
+            FilterOptions();
+            return;
+        }
+
+        switch (e.Key)
+        {
+            case "ArrowDown":
+                if (_filteredOptions.Count > 0)
+                {
+                    _highlightedIndex = (_highlightedIndex + 1) % _filteredOptions.Count;
+                }
+                break;
+
+            case "ArrowUp":
+                if (_filteredOptions.Count > 0)
+                {
+                    _highlightedIndex = _highlightedIndex <= 0
+                        ? _filteredOptions.Count - 1
+                        : _highlightedIndex - 1;
+                }
+                break;
+
+            case "Enter":
+                if (_highlightedIndex >= 0 && _highlightedIndex < _filteredOptions.Count)
+                {
+                    await SelectOption(_filteredOptions[_highlightedIndex]);
+                }
+                break;
+
+            case "Escape":
+                _isOpen = false;
+                _highlightedIndex = -1;
+                break;
+        }
+    }
+
+    private async Task SelectOption(AutocompleteOption option)
+    {
+        _searchText = option.Text;
+        _isOpen = false;
+        _highlightedIndex = -1;
+
+        await ValueChanged.InvokeAsync(option.Value);
+        await DisplayTextChanged.InvokeAsync(option.Text);
+    }
+
+    private void FilterOptions()
+    {
+        if (string.IsNullOrWhiteSpace(_searchText))
+        {
+            _filteredOptions = Options.ToList();
+        }
+        else
+        {
+            _filteredOptions = Options
+                .Where(o => o.Text.Contains(_searchText, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+    }
+
+    public record AutocompleteOption(string Value, string Text);
+}

--- a/src/Nutrir.Web/Components/UI/Autocomplete.razor.css
+++ b/src/Nutrir.Web/Components/UI/Autocomplete.razor.css
@@ -1,0 +1,38 @@
+.autocomplete-wrapper {
+    position: relative;
+}
+
+.autocomplete-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 50;
+    margin-top: var(--space-1);
+    padding: var(--space-1) 0;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border-input);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    list-style: none;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.autocomplete-option {
+    padding: var(--space-2) var(--space-4);
+    font-size: var(--text-base);
+    color: var(--color-text);
+    cursor: pointer;
+    transition: background var(--duration-fast) var(--ease-default);
+}
+
+.autocomplete-option:hover,
+.autocomplete-option.focused {
+    background: var(--color-bg-alt);
+}
+
+.autocomplete-option.selected {
+    background: var(--color-primary-muted);
+    font-weight: 500;
+}


### PR DESCRIPTION
## Summary

- Created a reusable `Autocomplete` component with text input, filtered dropdown, full keyboard navigation (ArrowUp/Down, Enter, Escape), ARIA combobox pattern, auto-selection on single result, and proper Blazor parameter binding
- Updated `ClientCreate.razor` to show a nutritionist picker field (replacing silent auto-assignment), defaulting to current user if they are a Nutritionist, with `[Required]` validation
- Updated `ClientEdit.razor` to replace the raw "Primary Nutritionist ID" text input with the autocomplete picker, pre-populated with the current nutritionist's name

## Files Changed

- `src/Nutrir.Web/Components/UI/Autocomplete.razor` (new)
- `src/Nutrir.Web/Components/UI/Autocomplete.razor.css` (new)
- `src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor` (modified)
- `src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor` (modified)

## Review Status

- Code Review: APPROVED (after 1 fix iteration)
- UI Review: APPROVED (after 1 fix iteration)
- Unresolved items: none

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)