### PR TITLE
Polish dashboard layout and clean up rough edges

### DIFF
--- a/src/Nutrir.Web/Components/Layout/IconRailSidebar.razor
+++ b/src/Nutrir.Web/Components/Layout/IconRailSidebar.razor
@@ -55,17 +55,6 @@
             </svg>
         </NavLink>
 
-        <NavLink class="rail-item" href="counter" title="Counter">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
-            </svg>
-        </NavLink>
-
-        <NavLink class="rail-item" href="weather" title="Weather">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/>
-            </svg>
-        </NavLink>
     </div>
 
     <div class="rail-footer">

--- a/src/Nutrir.Web/Components/Layout/TopBar.razor
+++ b/src/Nutrir.Web/Components/Layout/TopBar.razor
@@ -1,6 +1,15 @@
+@implements IDisposable
+@inject NavigationManager NavigationManager
+
 <header class="cc-topbar">
     <div class="cc-topbar-left">
-        <span class="cc-breadcrumb" style="font-weight: 500; color: var(--color-text);">Nutrir</span>
+        <div class="cc-topbar-title-group">
+            <span class="cc-breadcrumb" style="font-weight: 500; color: var(--color-text);">Nutrir</span>
+            @if (_isHome)
+            {
+                <span class="cc-topbar-subtitle">Dashboard overview</span>
+            }
+        </div>
     </div>
     <div class="cc-topbar-right">
         <div class="cc-search">
@@ -11,3 +20,30 @@
         </div>
     </div>
 </header>
+
+@code {
+    private bool _isHome;
+
+    protected override void OnInitialized()
+    {
+        UpdateIsHome();
+        NavigationManager.LocationChanged += OnLocationChanged;
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        UpdateIsHome();
+        StateHasChanged();
+    }
+
+    private void UpdateIsHome()
+    {
+        var relative = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        _isHome = string.IsNullOrEmpty(relative) || relative == "/";
+    }
+
+    public void Dispose()
+    {
+        NavigationManager.LocationChanged -= OnLocationChanged;
+    }
+}

--- a/src/Nutrir.Web/Components/Pages/Home.razor
+++ b/src/Nutrir.Web/Components/Pages/Home.razor
@@ -17,7 +17,21 @@
 
 @if (_loading)
 {
-    <div class="cc-empty-state">Loading dashboard...</div>
+    <div class="cc-skeleton-container">
+        <div class="cc-skeleton cc-skeleton-greeting"></div>
+        <div class="cc-skeleton-metrics">
+            <div class="cc-skeleton cc-skeleton-metric"></div>
+            <div class="cc-skeleton cc-skeleton-metric"></div>
+            <div class="cc-skeleton cc-skeleton-metric"></div>
+            <div class="cc-skeleton cc-skeleton-metric"></div>
+            <div class="cc-skeleton cc-skeleton-metric"></div>
+        </div>
+        <div class="cc-skeleton-panels">
+            <div class="cc-skeleton cc-skeleton-panel"></div>
+            <div class="cc-skeleton cc-skeleton-panel"></div>
+            <div class="cc-skeleton cc-skeleton-panel"></div>
+        </div>
+    </div>
 }
 else
 {
@@ -93,7 +107,13 @@ else
             <ChildContent>
                 @if (_recentClients.Count == 0)
                 {
-                    <div class="cc-empty-state">No clients yet</div>
+                    <div class="cc-empty-state">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="margin: 0 auto; display: block; opacity: 0.4;">
+                            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/>
+                        </svg>
+                        <p>No clients yet</p>
+                        <a href="/clients/new" class="cc-empty-cta">Add your first client</a>
+                    </div>
                 }
                 else
                 {
@@ -142,7 +162,12 @@ else
         <Panel Title="Alerts & Reminders" Count="@_consentAlerts.Count">
             @if (_consentAlerts.Count == 0)
             {
-                <div class="cc-empty-state">No alerts</div>
+                <div class="cc-empty-state">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--color-success)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="margin: 0 auto; display: block;">
+                        <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/>
+                    </svg>
+                    <p>All clear — no alerts</p>
+                </div>
             }
             else
             {
@@ -175,7 +200,7 @@ else
                 {
                     @foreach (var plan in _recentMealPlans)
                     {
-                        <a href="/meal-plans/@plan.Id" class="cc-list-item" style="text-decoration:none; color:inherit;">
+                        <a href="/meal-plans/@plan.Id" class="cc-list-item">
                             <div class="cc-list-content">
                                 <div class="cc-list-primary">@plan.Title</div>
                                 <div class="cc-list-secondary">@plan.ClientFirstName @plan.ClientLastName</div>

--- a/src/Nutrir.Web/wwwroot/css/layout.css
+++ b/src/Nutrir.Web/wwwroot/css/layout.css
@@ -300,11 +300,13 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   padding: var(--space-3) var(--space-4);
-  transition: box-shadow var(--duration-fast) var(--ease-default);
+  transition: box-shadow var(--duration-fast) var(--ease-default),
+              transform var(--duration-fast) var(--ease-default);
 }
 
 .cc-metric:hover {
   box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
 }
 
 .cc-metric-row {
@@ -367,6 +369,7 @@
 .cc-panel {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
+  border-top: 2px solid rgba(var(--rgb-primary), 0.35);
   border-radius: var(--radius-lg);
   overflow: hidden;
   animation: fadeUp 400ms var(--ease-default) both;
@@ -418,6 +421,8 @@
   transition: background var(--duration-fast) var(--ease-default);
   cursor: pointer;
   font-size: var(--text-sm);
+  text-decoration: none;
+  color: inherit;
 }
 
 .cc-list-item:last-child {
@@ -835,6 +840,105 @@
 .cc-empty-state p {
   margin-top: var(--space-2);
   font-size: var(--text-xs);
+}
+
+.cc-empty-cta {
+  display: inline-block;
+  margin-top: var(--space-3);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: color var(--duration-fast) var(--ease-default);
+}
+
+.cc-empty-cta:hover {
+  color: var(--color-primary-hover);
+}
+
+
+/* ── Skeleton Loading ─────────────────────────────────────── */
+
+@keyframes shimmer {
+  0%   { background-position: -400px 0; }
+  100% { background-position: 400px 0; }
+}
+
+.cc-skeleton {
+  background: linear-gradient(
+    90deg,
+    rgba(var(--rgb-accent), 0.08) 25%,
+    rgba(var(--rgb-accent), 0.16) 50%,
+    rgba(var(--rgb-accent), 0.08) 75%
+  );
+  background-size: 800px 100%;
+  animation: shimmer 1.6s infinite linear;
+  border-radius: var(--radius-lg);
+}
+
+.cc-skeleton-container {
+  padding: 0;
+}
+
+.cc-skeleton-greeting {
+  height: 48px;
+  width: 280px;
+  margin-bottom: var(--space-4);
+}
+
+.cc-skeleton-metrics {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.cc-skeleton-metric {
+  height: 72px;
+}
+
+.cc-skeleton-panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr 0.8fr;
+  gap: var(--space-4);
+}
+
+.cc-skeleton-panel {
+  height: 240px;
+}
+
+@media (max-width: 1100px) {
+  .cc-skeleton-panels {
+    grid-template-columns: 1fr 1fr;
+  }
+  .cc-skeleton-metrics {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .cc-skeleton-panels {
+    grid-template-columns: 1fr;
+  }
+  .cc-skeleton-metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+
+/* ── TopBar Subtitle ──────────────────────────────────────── */
+
+.cc-topbar-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.cc-topbar-subtitle {
+  font-size: 0.625rem;
+  color: var(--color-text-muted);
+  font-weight: 400;
+  letter-spacing: 0.02em;
 }
 
 


### PR DESCRIPTION
## Summary
- Remove Blazor template leftover pages (Counter, Weather) from the sidebar
- Replace plain "Loading dashboard..." text with skeleton shimmer placeholders matching the dashboard grid layout
- Standardize empty states: "Recent Clients" gets a person icon + "Add your first client" CTA, "Alerts" shows a green checkmark with "All clear"
- Remove inline `style` attributes from meal plan links (handled by `.cc-list-item` CSS)
- Add subtle 2px top-accent border on `.cc-panel` for visual hierarchy
- Add `translateY(-1px)` lift on `.cc-metric:hover` for card interactivity
- Add "Dashboard overview" subtitle in TopBar when on the home page

## Test plan
- [ ] Verify sidebar no longer shows Counter/Weather links
- [ ] Dashboard loading shows skeleton shimmer briefly before content
- [ ] Empty states are consistent with icons and CTAs across all panels
- [ ] Meal plan list items render correctly without inline styles
- [ ] Panels have subtle top accent borders
- [ ] Metric cards lift on hover
- [ ] TopBar shows "Dashboard overview" subtitle only on the home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)