### PR TITLE
feat: improve AI assistant response formatting

### DIFF
--- a/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor
+++ b/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor
@@ -488,6 +488,12 @@
             "<div class=\"cc-ai-h1\">$1</div>",
             System.Text.RegularExpressions.RegexOptions.Multiline);
 
+        // Blockquotes
+        escaped = System.Text.RegularExpressions.Regex.Replace(escaped,
+            @"^&gt; (.+)$",
+            "<div class=\"cc-ai-blockquote\">$1</div>",
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+
         // Horizontal rules
         escaped = System.Text.RegularExpressions.Regex.Replace(escaped,
             @"^---+$",
@@ -534,13 +540,32 @@
 
         // Clean up excessive <br/> around block elements
         escaped = System.Text.RegularExpressions.Regex.Replace(escaped,
-            @"(<br/>)+\s*(<(?:div|table|ul|ol|hr|pre|blockquote)[ >])",
+            @"(<br/>)+\s*(<(?:div|table|ul|ol|hr|pre)[ >])",
             "$2");
         escaped = System.Text.RegularExpressions.Regex.Replace(escaped,
-            @"(</(?:div|table|ul|ol|hr|pre|blockquote)>)\s*(<br/>)+",
+            @"(</(?:div|table|ul|ol|hr|pre)>)\s*(<br/>)+",
             "$1");
 
         return escaped;
+    }
+
+    private static readonly HashSet<string> StatusSuccess = new(StringComparer.OrdinalIgnoreCase)
+        { "Confirmed", "Active", "Completed" };
+    private static readonly HashSet<string> StatusWarning = new(StringComparer.OrdinalIgnoreCase)
+        { "Scheduled", "Pending", "Draft" };
+    private static readonly HashSet<string> StatusError = new(StringComparer.OrdinalIgnoreCase)
+        { "Cancelled", "No-show", "Expired" };
+
+    private static string ApplyStatusBadge(string cell)
+    {
+        var trimmed = cell.Trim();
+        if (StatusSuccess.Contains(trimmed))
+            return $"<span class=\"cc-ai-status-success\">{cell}</span>";
+        if (StatusWarning.Contains(trimmed))
+            return $"<span class=\"cc-ai-status-warning\">{cell}</span>";
+        if (StatusError.Contains(trimmed))
+            return $"<span class=\"cc-ai-status-error\">{cell}</span>";
+        return cell;
     }
 
     private static string ConvertTable(string markdown)
@@ -568,7 +593,7 @@
             var cells = lines[i].Split('|').Select(c => c.Trim()).ToArray();
             sb.Append("<tr>");
             foreach (var c in cells)
-                sb.Append($"<td>{c}</td>");
+                sb.Append($"<td>{ApplyStatusBadge(c)}</td>");
             sb.Append("</tr>");
         }
         sb.Append("</tbody></table></div>");

--- a/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor.css
+++ b/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor.css
@@ -161,7 +161,7 @@
     padding: var(--space-2) var(--space-3);
     border-radius: var(--radius-md);
     font-size: var(--text-sm);
-    line-height: 1.5;
+    line-height: var(--leading-relaxed);
     overflow-wrap: break-word;
     word-break: break-word;
     overflow-x: auto;
@@ -208,24 +208,37 @@
 
 .cc-ai-msg--assistant .cc-ai-msg-content li {
     margin-left: 0;
+    margin-bottom: var(--space-1);
+    line-height: var(--leading-normal);
+}
+
+.cc-ai-msg--assistant .cc-ai-msg-content li::marker {
+    color: var(--color-primary);
 }
 
 /* Header hierarchy */
 ::deep .cc-ai-h1 {
-    font-size: 1.1rem;
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
     font-weight: 700;
     margin: 0.75rem 0 0.25rem;
+    padding-bottom: var(--space-1);
+    border-bottom: 1px solid var(--color-primary-muted);
 }
 
 ::deep .cc-ai-h2 {
-    font-size: 0.95rem;
+    font-family: var(--font-display);
+    font-size: var(--text-base);
     font-weight: 600;
     margin: 0.5rem 0 0.25rem;
 }
 
 ::deep .cc-ai-h3 {
-    font-size: 0.875rem;
+    font-size: var(--text-xs);
     font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider);
+    color: var(--color-text-muted);
     margin: 0.375rem 0 0.125rem;
 }
 
@@ -235,6 +248,8 @@
     margin: 0.5rem 0;
     padding-bottom: 0.375rem;
     -webkit-overflow-scrolling: touch;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
 }
 
 /* Table styling */
@@ -242,18 +257,78 @@
     border-collapse: collapse;
     font-size: var(--text-xs);
     white-space: nowrap;
+    width: 100%;
 }
 
 ::deep .cc-ai-table th,
 ::deep .cc-ai-table td {
     padding: var(--space-1) var(--space-2);
-    border: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border);
     text-align: left;
 }
 
 ::deep .cc-ai-table th {
-    background: var(--color-bg);
+    background: var(--color-bg-alt);
     font-weight: 600;
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider);
+    color: var(--color-text-muted);
+}
+
+::deep .cc-ai-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+::deep .cc-ai-table tbody tr:hover {
+    background: color-mix(in srgb, var(--color-primary) 4%, transparent);
+}
+
+/* Status badges in tables */
+::deep .cc-ai-status-success {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    background: rgba(34, 134, 58, 0.12);
+    color: var(--color-success, #22863a);
+}
+
+::deep .cc-ai-status-warning {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    background: rgba(230, 168, 23, 0.12);
+    color: var(--color-warning, #e6a817);
+}
+
+::deep .cc-ai-status-error {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    background: rgba(215, 58, 73, 0.12);
+    color: var(--color-error, #d73a49);
+}
+
+/* Blockquote styling */
+::deep .cc-ai-blockquote {
+    margin: var(--space-2) 0;
+    padding: var(--space-2) var(--space-3);
+    border-left: 3px solid var(--color-primary);
+    background: var(--color-primary-muted);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+/* Horizontal rule styling */
+::deep hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: var(--space-3) 0;
 }
 
 /* Entity link chips */


### PR DESCRIPTION
## Summary
- Restyle headings with display font hierarchy (H1 with bottom border, H3 uppercase labels) using existing design tokens
- Replace grid-border tables with the app's data table convention: horizontal-only borders, styled uppercase headers, row hover tint, full-width layout
- Add automatic status badges in table cells — green (Confirmed/Active/Completed), amber (Scheduled/Pending/Draft), red (Cancelled/No-show/Expired)
- Improve list styling with primary-colored markers and better spacing
- Add blockquote parsing (`> text`) with primary left-border accent
- Style horizontal rules and increase assistant message line-height for readability

## Test plan
- [ ] `docker compose up --build` and open AI assistant sidebar
- [ ] Ask "Give me a practice overview" — verify heading hierarchy, table styling, and status badges
- [ ] Verify bullet lists have colored markers and proper spacing
- [ ] Ask a recommendation question to trigger blockquotes
- [ ] Test in both normal and wide mode
- [ ] Confirm entity link chips still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)