### PR TITLE
fix: add explicit consent capture to AI create_client tool

### DIFF
--- a/src/Nutrir.Infrastructure/Services/AiAgentService.cs
+++ b/src/Nutrir.Infrastructure/Services/AiAgentService.cs
@@ -46,7 +46,7 @@ public class AiAgentService : IAiAgentService
 
         ### Write Operations
         You can create, update, and delete data across all domains:
-        - **Clients**: Create, update, and delete client records
+        - **Clients**: Create, update, and delete client records. **Consent requirement**: Before creating a new client, you MUST explicitly ask the practitioner to confirm that the client has given consent for their data to be stored. This is a regulatory/compliance requirement — do not skip it. Only set `consent_given: true` after the practitioner has explicitly confirmed consent.
         - **Appointments**: Create, update, cancel, and delete appointments
         - **Meal Plans**: Create, update metadata, activate, archive, duplicate, and delete meal plans (note: you cannot edit meal plan content — days, slots, and items — via chat)
         - **Goals**: Create, update, achieve, abandon, and delete progress goals


### PR DESCRIPTION
## Summary

- Added `consent_given` as a **required** boolean parameter to the `create_client` AI tool
- Added an early guard in `HandleCreateClient` that returns a structured error when consent is not confirmed, instead of letting `ClientService` throw a raw exception
- Updated the tool description and system prompt to instruct the AI to explicitly ask the practitioner for consent confirmation before creating a client
- Consent status is now shown in the tool confirmation dialog (e.g., "create a client named John Doe (consent: confirmed)")

The conversation history serves as the audit trail for consent confirmation, satisfying the compliance requirement that consent be explicit, auditable, and separate from the generic tool allow/deny dialog.

Closes #42

## Test plan

- [ ] Ask the AI assistant to create a client — it should ask for consent confirmation before calling the tool
- [ ] Confirm consent when asked — the tool should execute successfully with `consent_given: true`
- [ ] Verify the confirmation dialog shows "(consent: confirmed)"
- [ ] Attempt to create a client without confirming consent — should get a structured error, not a raw exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)