### PR TITLE
fix: support multiple sequential tool confirmations in AI panel

### DIFF
--- a/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor
+++ b/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor
@@ -86,11 +86,11 @@
                         else
                         {
                             @((MarkupString)RenderMarkdown(msg.Text))
-                            @if (msg.PendingConfirmation is not null)
+                            @foreach (var confirmation in msg.Confirmations)
                             {
-                                var isElevated = msg.PendingConfirmation.Tier == ConfirmationTier.Elevated;
+                                var isElevated = confirmation.Request.Tier == ConfirmationTier.Elevated;
                                 <div class="cc-ai-confirmation @(isElevated ? "cc-ai-confirmation--elevated" : "")">
-                                    @if (msg.ConfirmationResult is null)
+                                    @if (confirmation.Result is null)
                                     {
                                         <p class="cc-ai-confirmation-desc">
                                             @if (isElevated)
@@ -100,17 +100,17 @@
                                                     <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
                                                 </svg>
                                             }
-                                            The assistant wants to <strong>@msg.PendingConfirmation.Description</strong>
+                                            The assistant wants to <strong>@confirmation.Request.Description</strong>
                                         </p>
                                         <div class="cc-ai-confirmation-actions">
-                                            <button class="cc-ai-btn-allow" @onclick="() => HandleConfirmation(msg, true)">Allow</button>
-                                            <button class="cc-ai-btn-deny" @onclick="() => HandleConfirmation(msg, false)">Deny</button>
+                                            <button class="cc-ai-btn-allow" @onclick="() => HandleConfirmation(confirmation, true)">Allow</button>
+                                            <button class="cc-ai-btn-deny" @onclick="() => HandleConfirmation(confirmation, false)">Deny</button>
                                         </div>
                                     }
                                     else
                                     {
                                         <p class="cc-ai-confirmation-resolved">
-                                            @(msg.ConfirmationResult == true ? "Allowed" : "Denied"): <strong>@msg.PendingConfirmation.Description</strong>
+                                            @(confirmation.Result == true ? "Allowed" : "Denied"): <strong>@confirmation.Request.Description</strong>
                                         </p>
                                     }
                                 </div>
@@ -312,7 +312,10 @@
             {
                 if (evt.ConfirmationRequest is not null)
                 {
-                    assistantMsg.PendingConfirmation = evt.ConfirmationRequest;
+                    assistantMsg.Confirmations.Add(new ConfirmationRecord
+                    {
+                        Request = evt.ConfirmationRequest
+                    });
                     assistantMsg.ToolStatus = null;
                     StateHasChanged();
                     // Stream naturally pauses here waiting for user response
@@ -370,13 +373,13 @@
         }
     }
 
-    private void HandleConfirmation(ChatMessage msg, bool allowed)
+    private void HandleConfirmation(ConfirmationRecord confirmation, bool allowed)
     {
-        if (msg.PendingConfirmation is null || msg.ConfirmationResult is not null)
+        if (confirmation.Result is not null)
             return;
 
-        msg.ConfirmationResult = allowed;
-        AiAgent.RespondToConfirmation(msg.PendingConfirmation.ToolCallId, allowed);
+        confirmation.Result = allowed;
+        AiAgent.RespondToConfirmation(confirmation.Request.ToolCallId, allowed);
         StateHasChanged();
     }
 
@@ -642,13 +645,24 @@
         return (null, null);
     }
 
+    private class ConfirmationRecord
+    {
+        public ToolConfirmationRequest Request { get; init; } = default!;
+        public bool? Result { get; set; }
+    }
+
     private class ChatMessage
     {
         public string Role { get; init; } = "";
         public string Text { get; set; } = "";
         public string? ToolStatus { get; set; }
-        public ToolConfirmationRequest? PendingConfirmation { get; set; }
-        public bool? ConfirmationResult { get; set; }
+        public List<ConfirmationRecord> Confirmations { get; } = [];
+
+        /// <summary>
+        /// Returns the active (unresolved) confirmation, if any.
+        /// </summary>
+        public ConfirmationRecord? ActiveConfirmation =>
+            Confirmations.LastOrDefault(c => c.Result is null);
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary

- Replaced single `PendingConfirmation`/`ConfirmationResult` pair on `ChatMessage` with a `List<ConfirmationRecord>`, where each record independently tracks its request and result
- Each sequential tool confirmation now renders its own Allow/Deny prompt, and resolved confirmations show as history within the same message
- No backend changes needed — `AiAgentService.cs` already handles multiple sequential confirmations correctly

## Root Cause

The `ChatMessage` class used a single `ConfirmationResult` field that was never reset when a new confirmation arrived. After approving the first confirmation, `ConfirmationResult` remained `true`, causing the template to render "Allowed" for the second confirmation instead of new Allow/Deny buttons — deadlocking the agentic loop.

## Test plan

- [ ] Ask AI assistant to activate two draft meal plans — both confirmations should appear sequentially
- [ ] After approving both, verify the history shows "Allowed: [first action]" and "Allowed: [second action]"
- [ ] Deny the second confirmation — verify it shows "Denied" and the first still shows "Allowed"
- [ ] Single-confirmation flows still work as before
- [ ] Input re-enables after all tool calls complete

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)