### PR TITLE
feat: add consent form download on client creation page

### DIFF
--- a/src/Nutrir.Core/Interfaces/IConsentFormService.cs
+++ b/src/Nutrir.Core/Interfaces/IConsentFormService.cs
@@ -8,6 +8,10 @@ public interface IConsentFormService
 
     Task<byte[]> GenerateDocxAsync(int clientId, string userId);
 
+    byte[] GeneratePreviewPdf(string clientName, string practitionerName);
+
+    byte[] GeneratePreviewDocx(string clientName, string practitionerName);
+
     Task<ConsentFormDto> RecordDigitalSignatureAsync(int clientId, string userId);
 
     Task<ConsentFormDto> MarkPhysicallySignedAsync(int clientId, string userId, string? notes = null);

--- a/src/Nutrir.Infrastructure/Services/ConsentFormService.cs
+++ b/src/Nutrir.Infrastructure/Services/ConsentFormService.cs
@@ -77,6 +77,18 @@ public class ConsentFormService : IConsentFormService
         return docxBytes;
     }
 
+    public byte[] GeneratePreviewPdf(string clientName, string practitionerName)
+    {
+        var content = _template.Generate(clientName, practitionerName, DateTime.UtcNow);
+        return ConsentFormPdfRenderer.Render(content);
+    }
+
+    public byte[] GeneratePreviewDocx(string clientName, string practitionerName)
+    {
+        var content = _template.Generate(clientName, practitionerName, DateTime.UtcNow);
+        return ConsentFormDocxRenderer.Render(content, _options.DocxTemplatePath);
+    }
+
     public async Task<ConsentFormDto> RecordDigitalSignatureAsync(int clientId, string userId)
     {
         var form = await GetOrCreateFormAsync(clientId, userId, ConsentSignatureMethod.Digital);

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
@@ -49,14 +49,14 @@
                     <FormGroup Label="First Name" Id="firstName" Error="@GetFieldError(nameof(_model.FirstName))">
                         <FormInput Id="firstName"
                                    Value="@_model.FirstName"
-                                   ValueChanged="@(v => _model.FirstName = v)"
+                                   ValueChanged="OnFirstNameChanged"
                                    Placeholder="Enter first name" />
                     </FormGroup>
 
                     <FormGroup Label="Last Name" Id="lastName" Error="@GetFieldError(nameof(_model.LastName))">
                         <FormInput Id="lastName"
                                    Value="@_model.LastName"
-                                   ValueChanged="@(v => _model.LastName = v)"
+                                   ValueChanged="OnLastNameChanged"
                                    Placeholder="Enter last name" />
                     </FormGroup>
                 </div>
@@ -130,7 +130,7 @@
                                    checked="@(_model.ConsentMethod == ConsentSignatureMethod.Physical)"
                                    @onchange="@(() => OnConsentMethodChanged(ConsentSignatureMethod.Physical))" />
                             <span class="consent-method-label">Print & sign later</span>
-                            <span class="consent-method-desc">Download and print the form from the client detail page</span>
+                            <span class="consent-method-desc">Download, print, and return the signed form</span>
                         </label>
                     </div>
 
@@ -146,7 +146,24 @@
                     {
                         <div class="consent-info-alert">
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
-                            <span>The consent form can be downloaded and printed from the client detail page after creation. The client will be created with consent pending.</span>
+                            <span>Download and print the consent form for the client to sign. The client will be created with consent pending.</span>
+                        </div>
+                        <div class="consent-download-actions">
+                            @if (_hasClientName)
+                            {
+                                <a href="@GetPreviewUrl("pdf")" target="_blank" class="btn btn-sm btn-outline">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                                    Download PDF
+                                </a>
+                                <a href="@GetPreviewUrl("docx")" target="_blank" class="btn btn-sm btn-outline">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                                    Download DOCX
+                                </a>
+                            }
+                            else
+                            {
+                                <span class="consent-download-hint">Enter the client's name to enable download</span>
+                            }
                         </div>
                     }
                 </div>
@@ -188,6 +205,17 @@
     private string? _nutritionistDisplayText;
     private ConsentFormContent? _consentContent;
 
+    private bool _hasClientName =>
+        !string.IsNullOrWhiteSpace(_model.FirstName) && !string.IsNullOrWhiteSpace(_model.LastName);
+
+    private string GetPreviewUrl(string format)
+    {
+        var clientName = Uri.EscapeDataString($"{_model.FirstName} {_model.LastName}".Trim());
+        var practitionerName = Uri.EscapeDataString(
+            string.IsNullOrWhiteSpace(_nutritionistDisplayText) ? "(Practitioner)" : _nutritionistDisplayText);
+        return $"/api/consent-form/preview/{format}?clientName={clientName}&practitionerName={practitionerName}";
+    }
+
     protected override async Task OnInitializedAsync()
     {
         _editContext = new EditContext(_model);
@@ -211,6 +239,16 @@
 
         // Generate consent form content for preview
         _consentContent = ConsentFormTemplate.Generate("(Client Name)", "(Practitioner)", DateTime.UtcNow);
+    }
+
+    private void OnFirstNameChanged(string value)
+    {
+        _model.FirstName = value;
+    }
+
+    private void OnLastNameChanged(string value)
+    {
+        _model.LastName = value;
     }
 
     private void OnPhoneChanged(string value)

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor.css
@@ -174,6 +174,26 @@
     margin-top: 2px;
 }
 
+/* ── Consent Download Actions ────────────────────────── */
+.consent-download-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+}
+
+.consent-download-actions .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.consent-download-hint {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    font-style: italic;
+}
+
 /* ── Consent Row ──────────────────────────────────────── */
 .consent-row {
     padding: var(--space-2) 0;


### PR DESCRIPTION
## Summary
- Adds PDF and DOCX download buttons on the Create Client page when "Physical (print & sign)" consent method is selected
- Consent forms are generated from in-memory form data (client name + practitioner) without requiring a saved client record
- New preview API endpoints (`/api/consent-form/preview/pdf` and `/docx`) with input validation and role-based authorization
- Download buttons are disabled with a hint message until the client name fields are filled in

## Changes
- **IConsentFormService** — added `GeneratePreviewPdf` and `GeneratePreviewDocx` methods
- **ConsentFormService** — implemented preview methods (pure template + renderer, no DB)
- **ConsentFormEndpoints** — added `/api/consent-form/preview/{pdf,docx}` endpoints with validation
- **ClientCreate.razor** — added download buttons in the physical consent section, named handlers for name field re-renders
- **ClientCreate.razor.css** — added styles for the download actions area

## Test plan
- [ ] Select "Print & sign later" on `/clients/new` — download buttons appear
- [ ] Download PDF and DOCX — forms contain entered client name and selected practitioner
- [ ] Leave name fields empty — hint text shown instead of buttons
- [ ] Verify existing client detail page downloads still work unchanged
- [ ] Verify authorization: unauthenticated users cannot access preview endpoints

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)