### PR TITLE
feat: add meal plan metadata editing page

### DIFF
--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor
@@ -84,13 +84,15 @@
                 <div class="hero-actions">
                     @if (_plan.Status is MealPlanStatus.Draft)
                     {
-                        <Button Variant="ButtonVariant.Primary" OnClick="NavigateToEdit">Edit</Button>
+                        <Button Variant="ButtonVariant.Primary" OnClick="NavigateToEditDetails">Edit Details</Button>
+                        <Button Variant="ButtonVariant.Outline" OnClick="NavigateToEdit">Edit Meals</Button>
                         <Button Variant="ButtonVariant.Outline" OnClick="ActivatePlan">Activate</Button>
                         <Button Variant="ButtonVariant.Ghost" OnClick="@(() => _showDeleteConfirm = true)">Delete</Button>
                     }
                     else if (_plan.Status is MealPlanStatus.Active)
                     {
-                        <Button Variant="ButtonVariant.Primary" OnClick="NavigateToEdit">Edit</Button>
+                        <Button Variant="ButtonVariant.Primary" OnClick="NavigateToEditDetails">Edit Details</Button>
+                        <Button Variant="ButtonVariant.Outline" OnClick="NavigateToEdit">Edit Meals</Button>
                         <Button Variant="ButtonVariant.Outline" OnClick="DuplicatePlan">Duplicate</Button>
                         <Button Variant="ButtonVariant.Ghost" OnClick="ArchivePlan">Archive</Button>
                     }
@@ -288,6 +290,7 @@
     }
 
     private void NavigateToEdit() => NavigationManager.NavigateTo($"/meal-plans/{Id}/edit");
+    private void NavigateToEditDetails() => NavigationManager.NavigateTo($"/meal-plans/{Id}/edit-details");
 
     private async Task ActivatePlan()
     {

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanList.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanList.razor
@@ -100,9 +100,13 @@
                                     </a>
                                     @if (plan.Status is MealPlanStatus.Draft or MealPlanStatus.Active)
                                     {
-                                        <a href="meal-plans/@plan.Id/edit" class="btn-icon" title="Edit">
+                                        <a href="meal-plans/@plan.Id/edit-details" class="btn-icon" title="Edit Details">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/><path d="M10 9H8"/></svg>
+                                            <span class="sr-only">Edit Details</span>
+                                        </a>
+                                        <a href="meal-plans/@plan.Id/edit" class="btn-icon" title="Edit Meals">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
-                                            <span class="sr-only">Edit</span>
+                                            <span class="sr-only">Edit Meals</span>
                                         </a>
                                     }
                                 </div>

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor
@@ -1,0 +1,369 @@
+@page "/meal-plans/{Id:int}/edit-details"
+@rendermode InteractiveServer
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Forms
+@using System.ComponentModel.DataAnnotations
+@using System.Security.Claims
+@using Nutrir.Core.DTOs
+@using Nutrir.Core.Enums
+@using Nutrir.Core.Interfaces
+@attribute [Authorize(Roles = "Admin,Nutritionist,Assistant")]
+@inject IMealPlanService MealPlanService
+@inject IClientService ClientService
+@inject NavigationManager NavigationManager
+
+<PageTitle>Edit Meal Plan Details — Nutrir</PageTitle>
+
+<div class="form-page">
+    <div class="page-header">
+        <a href="/meal-plans/@Id" class="back-link">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m15 18-6-6 6-6"/>
+            </svg>
+        </a>
+        <h1 class="page-title">Edit Meal Plan Details</h1>
+    </div>
+
+    @if (_isLoading)
+    {
+        <p>Loading...</p>
+    }
+    else if (_notFound)
+    {
+        <div class="table-card">
+            <div class="error-banner">Meal plan not found.</div>
+        </div>
+    }
+    else
+    {
+        <div class="table-card">
+            <EditForm Model="_model" OnValidSubmit="HandleSubmit" FormName="EditMealPlanMetadata">
+                <DataAnnotationsValidator />
+
+                <div class="section-header" @onclick="@(() => _planDetailsOpen = !_planDetailsOpen)">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/><path d="M10 9H8"/>
+                    </svg>
+                    Plan Details
+                    <svg class="section-chevron @(_planDetailsOpen ? "" : "collapsed")" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="m6 9 6 6 6-6"/>
+                    </svg>
+                </div>
+                @if (_planDetailsOpen)
+                {
+                    <div class="form-body">
+                        <FormGroup Label="Client" Id="clientId" Error="@GetFieldError(nameof(_model.ClientId))">
+                            <FormSelect Id="clientId"
+                                        Value="@_model.ClientId"
+                                        ValueChanged="@(v => _model.ClientId = v)">
+                                <option value="">Select a client...</option>
+                                @foreach (var client in _clients)
+                                {
+                                    <option value="@client.Id">@client.FirstName @client.LastName</option>
+                                }
+                            </FormSelect>
+                        </FormGroup>
+
+                        <FormGroup Label="Title" Id="title" Error="@GetFieldError(nameof(_model.Title))">
+                            <FormInput Id="title"
+                                       Value="@_model.Title"
+                                       ValueChanged="@(v => _model.Title = v)"
+                                       Placeholder="e.g. Week 1 — Weight Loss" />
+                        </FormGroup>
+
+                        <FormGroup Label="Description" Id="description">
+                            <textarea id="description"
+                                      class="form-input"
+                                      rows="2"
+                                      @bind="_model.Description"
+                                      placeholder="Overview or goals..."></textarea>
+                        </FormGroup>
+
+                        <div class="form-grid">
+                            <FormGroup Label="Start Date" Id="startDate">
+                                <FormInput Id="startDate" Type="date"
+                                           Value="@_model.StartDate"
+                                           ValueChanged="@(v => _model.StartDate = v)" />
+                            </FormGroup>
+
+                            <FormGroup Label="End Date" Id="endDate">
+                                <FormInput Id="endDate" Type="date"
+                                           Value="@_model.EndDate"
+                                           ValueChanged="@(v => _model.EndDate = v)" />
+                            </FormGroup>
+                        </div>
+
+                        <FormGroup Label="Number of Days" Id="days">
+                            <FormSelect Id="days"
+                                        Value="@_model.NumberOfDays"
+                                        ValueChanged="@(v => _model.NumberOfDays = v)">
+                                @for (var i = 1; i <= 7; i++)
+                                {
+                                    <option value="@i">@i @(i == 1 ? "day" : "days")</option>
+                                }
+                            </FormSelect>
+                        </FormGroup>
+                    </div>
+                }
+
+                <div class="section-header" @onclick="@(() => _nutritionOpen = !_nutritionOpen)">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M2 12h20"/><path d="M12 2v20"/><circle cx="12" cy="12" r="10"/>
+                    </svg>
+                    Nutrition Targets
+                    <svg class="section-chevron @(_nutritionOpen ? "" : "collapsed")" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="m6 9 6 6 6-6"/>
+                    </svg>
+                </div>
+                @if (_nutritionOpen)
+                {
+                    <div class="form-body">
+                        <div class="form-grid">
+                            <FormGroup Label="Calorie Target (kcal)" Id="calories">
+                                <FormInput Id="calories" Type="number"
+                                           Value="@_model.CalorieTarget"
+                                           ValueChanged="@(v => _model.CalorieTarget = v)"
+                                           Placeholder="e.g. 2000" />
+                            </FormGroup>
+                            <FormGroup Label="Protein Target (g)" Id="protein">
+                                <FormInput Id="protein" Type="number"
+                                           Value="@_model.ProteinTarget"
+                                           ValueChanged="@(v => _model.ProteinTarget = v)"
+                                           Placeholder="e.g. 150" />
+                            </FormGroup>
+                        </div>
+
+                        <div class="form-grid">
+                            <FormGroup Label="Carbs Target (g)" Id="carbs">
+                                <FormInput Id="carbs" Type="number"
+                                           Value="@_model.CarbsTarget"
+                                           ValueChanged="@(v => _model.CarbsTarget = v)"
+                                           Placeholder="e.g. 200" />
+                            </FormGroup>
+                            <FormGroup Label="Fat Target (g)" Id="fat">
+                                <FormInput Id="fat" Type="number"
+                                           Value="@_model.FatTarget"
+                                           ValueChanged="@(v => _model.FatTarget = v)"
+                                           Placeholder="e.g. 67" />
+                            </FormGroup>
+                        </div>
+                    </div>
+                }
+
+                <div class="section-header" @onclick="@(() => _notesOpen = !_notesOpen)">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/>
+                    </svg>
+                    Notes
+                    <svg class="section-chevron @(_notesOpen ? "" : "collapsed")" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="m6 9 6 6 6-6"/>
+                    </svg>
+                </div>
+                @if (_notesOpen)
+                {
+                    <div class="form-body">
+                        <FormGroup Label="Internal Notes" Id="notes">
+                            <textarea id="notes"
+                                      class="form-input"
+                                      rows="2"
+                                      @bind="_model.Notes"
+                                      placeholder="Practitioner notes..."></textarea>
+                        </FormGroup>
+
+                        <FormGroup Label="Client Instructions" Id="instructions">
+                            <textarea id="instructions"
+                                      class="form-input"
+                                      rows="2"
+                                      @bind="_model.Instructions"
+                                      placeholder="Instructions for the client..."></textarea>
+                        </FormGroup>
+                    </div>
+                }
+
+                @if (!string.IsNullOrEmpty(_errorMessage))
+                {
+                    <div class="error-banner">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg>
+                        @_errorMessage
+                    </div>
+                }
+
+                <div class="form-actions">
+                    <Button Variant="ButtonVariant.Primary" Type="submit" Disabled="@_isSubmitting">
+                        @if (_isSubmitting)
+                        {
+                            <span>Saving...</span>
+                        }
+                        else
+                        {
+                            <span>Save Changes</span>
+                        }
+                    </Button>
+                    <a href="/meal-plans/@Id" class="cancel-link">Cancel</a>
+                </div>
+            </EditForm>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public int Id { get; set; }
+    [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
+
+    private MealPlanFormModel _model = new();
+    private EditContext? _editContext;
+    private List<ClientDto> _clients = [];
+    private bool _isLoading = true;
+    private bool _notFound;
+    private bool _isSubmitting;
+    private string? _errorMessage;
+    private bool _planDetailsOpen = true;
+    private bool _nutritionOpen = true;
+    private bool _notesOpen = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _editContext = new EditContext(_model);
+        _clients = await ClientService.GetListAsync();
+
+        var plan = await MealPlanService.GetByIdAsync(Id);
+        if (plan is null)
+        {
+            _notFound = true;
+            _isLoading = false;
+            return;
+        }
+
+        if (plan.Status is MealPlanStatus.Archived)
+        {
+            NavigationManager.NavigateTo($"/meal-plans/{Id}");
+            return;
+        }
+
+        _model.ClientId = plan.ClientId.ToString();
+        _model.Title = plan.Title;
+        _model.Description = plan.Description;
+        _model.StartDate = plan.StartDate?.ToString("yyyy-MM-dd");
+        _model.EndDate = plan.EndDate?.ToString("yyyy-MM-dd");
+        _model.NumberOfDays = plan.Days.Count > 0 ? plan.Days.Count.ToString() : "7";
+        _model.CalorieTarget = plan.CalorieTarget?.ToString();
+        _model.ProteinTarget = plan.ProteinTargetG?.ToString();
+        _model.CarbsTarget = plan.CarbsTargetG?.ToString();
+        _model.FatTarget = plan.FatTargetG?.ToString();
+        _model.Notes = plan.Notes;
+        _model.Instructions = plan.Instructions;
+
+        _isLoading = false;
+    }
+
+    private async Task HandleSubmit()
+    {
+        _isSubmitting = true;
+        _errorMessage = null;
+
+        try
+        {
+            if (string.IsNullOrEmpty(_model.ClientId) || !int.TryParse(_model.ClientId, out var clientId))
+            {
+                _errorMessage = "Please select a client.";
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(_model.Title))
+            {
+                _errorMessage = "Title is required.";
+                return;
+            }
+
+            if (!int.TryParse(_model.NumberOfDays, out var numberOfDays))
+                numberOfDays = 7;
+
+            DateOnly? startDate = null;
+            if (!string.IsNullOrEmpty(_model.StartDate) && DateOnly.TryParse(_model.StartDate, out var sd))
+                startDate = sd;
+
+            DateOnly? endDate = null;
+            if (!string.IsNullOrEmpty(_model.EndDate) && DateOnly.TryParse(_model.EndDate, out var ed))
+                endDate = ed;
+
+            decimal? calorieTarget = null;
+            if (!string.IsNullOrEmpty(_model.CalorieTarget) && decimal.TryParse(_model.CalorieTarget, out var ct))
+                calorieTarget = ct;
+
+            decimal? proteinTarget = null;
+            if (!string.IsNullOrEmpty(_model.ProteinTarget) && decimal.TryParse(_model.ProteinTarget, out var pt))
+                proteinTarget = pt;
+
+            decimal? carbsTarget = null;
+            if (!string.IsNullOrEmpty(_model.CarbsTarget) && decimal.TryParse(_model.CarbsTarget, out var cbt))
+                carbsTarget = cbt;
+
+            decimal? fatTarget = null;
+            if (!string.IsNullOrEmpty(_model.FatTarget) && decimal.TryParse(_model.FatTarget, out var ft))
+                fatTarget = ft;
+
+            var authState = await AuthState;
+            var userId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+
+            var dto = new CreateMealPlanDto(
+                ClientId: clientId,
+                Title: _model.Title!,
+                Description: string.IsNullOrWhiteSpace(_model.Description) ? null : _model.Description,
+                StartDate: startDate,
+                EndDate: endDate,
+                CalorieTarget: calorieTarget,
+                ProteinTargetG: proteinTarget,
+                CarbsTargetG: carbsTarget,
+                FatTargetG: fatTarget,
+                Notes: string.IsNullOrWhiteSpace(_model.Notes) ? null : _model.Notes,
+                Instructions: string.IsNullOrWhiteSpace(_model.Instructions) ? null : _model.Instructions,
+                NumberOfDays: numberOfDays);
+
+            var success = await MealPlanService.UpdateMetadataAsync(Id, dto, userId);
+            if (success)
+            {
+                NavigationManager.NavigateTo($"/meal-plans/{Id}");
+            }
+            else
+            {
+                _errorMessage = "Failed to update the meal plan. It may have been deleted.";
+            }
+        }
+        catch
+        {
+            _errorMessage = "An error occurred while saving changes. Please try again.";
+        }
+        finally
+        {
+            _isSubmitting = false;
+        }
+    }
+
+    private string? GetFieldError(string fieldName)
+    {
+        if (_editContext is null) return null;
+        var messages = _editContext.GetValidationMessages(new FieldIdentifier(_model, fieldName));
+        return messages.FirstOrDefault();
+    }
+
+    private class MealPlanFormModel
+    {
+        [Required(ErrorMessage = "Client is required.")]
+        public string? ClientId { get; set; }
+
+        [Required(ErrorMessage = "Title is required.")]
+        public string? Title { get; set; }
+
+        public string? Description { get; set; }
+        public string? StartDate { get; set; }
+        public string? EndDate { get; set; }
+        public string NumberOfDays { get; set; } = "7";
+        public string? CalorieTarget { get; set; }
+        public string? ProteinTarget { get; set; }
+        public string? CarbsTarget { get; set; }
+        public string? FatTarget { get; set; }
+        public string? Notes { get; set; }
+        public string? Instructions { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Add new `/meal-plans/{id}/edit-details` page that mirrors the create form but loads existing data and calls `UpdateMetadataAsync`
- Split the single "Edit" button into "Edit Details" and "Edit Meals" on both the detail page and list page
- Archived plans redirect away from the edit-details page; only Draft/Active plans are editable

## Test plan
- [ ] Create a new meal plan — verify redirect to meal planner still works
- [ ] From detail page: click "Edit Details" — verify form loads with existing data, make changes, save — verify changes persisted
- [ ] From detail page: click "Edit Meals" — verify meal planner still works as before
- [ ] From list page: verify both edit actions (document icon for details, pencil for meals) are accessible
- [ ] Verify Archived plans do not show edit options

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)