### PR TITLE
feat: add audit log viewer page

### DIFF
--- a/src/Nutrir.Core/DTOs/AuditLogPageResult.cs
+++ b/src/Nutrir.Core/DTOs/AuditLogPageResult.cs
@@ -1,0 +1,7 @@
+namespace Nutrir.Core.DTOs;
+
+public record AuditLogPageResult(
+    List<AuditLogViewDto> Items,
+    int TotalCount,
+    int Page,
+    int PageSize);

--- a/src/Nutrir.Core/DTOs/AuditLogQueryRequest.cs
+++ b/src/Nutrir.Core/DTOs/AuditLogQueryRequest.cs
@@ -1,0 +1,13 @@
+using Nutrir.Core.Enums;
+
+namespace Nutrir.Core.DTOs;
+
+public record AuditLogQueryRequest(
+    int Page = 1,
+    int PageSize = 25,
+    DateTime? From = null,
+    DateTime? To = null,
+    string? Action = null,
+    string? EntityType = null,
+    AuditSource? Source = null,
+    string? SearchTerm = null);

--- a/src/Nutrir.Core/DTOs/AuditLogViewDto.cs
+++ b/src/Nutrir.Core/DTOs/AuditLogViewDto.cs
@@ -1,0 +1,15 @@
+using Nutrir.Core.Enums;
+
+namespace Nutrir.Core.DTOs;
+
+public record AuditLogViewDto(
+    int Id,
+    DateTime Timestamp,
+    string UserId,
+    string UserDisplayName,
+    string Action,
+    string EntityType,
+    string? EntityId,
+    string? Details,
+    string? IpAddress,
+    AuditSource Source);

--- a/src/Nutrir.Core/Interfaces/IAuditLogService.cs
+++ b/src/Nutrir.Core/Interfaces/IAuditLogService.cs
@@ -13,4 +13,10 @@ public interface IAuditLogService
         string? ipAddress = null);
 
     Task<List<AuditLogDto>> GetRecentAsync(int count = 10);
+
+    Task<AuditLogPageResult> QueryAsync(AuditLogQueryRequest request);
+
+    Task<List<string>> GetDistinctActionsAsync();
+
+    Task<List<string>> GetDistinctEntityTypesAsync();
 }

--- a/src/Nutrir.Web/Components/Layout/IconRailSidebar.razor
+++ b/src/Nutrir.Web/Components/Layout/IconRailSidebar.razor
@@ -58,6 +58,12 @@
             </svg>
         </NavLink>
 
+        <NavLink class="rail-item" href="admin/audit-log" title="Audit Log">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/>
+            </svg>
+        </NavLink>
+
     </div>
 
     <div class="rail-footer">

--- a/src/Nutrir.Web/Components/Pages/Admin/AuditLog.razor
+++ b/src/Nutrir.Web/Components/Pages/Admin/AuditLog.razor
@@ -1,0 +1,399 @@
+@page "/admin/audit-log"
+@rendermode InteractiveServer
+@using Microsoft.AspNetCore.Authorization
+@using Nutrir.Core.DTOs
+@using Nutrir.Core.Enums
+@using Nutrir.Core.Interfaces
+@using System.Security.Claims
+@attribute [Authorize(Roles = "Admin,Nutritionist")]
+@implements IDisposable
+@inject IAuditLogService AuditLogService
+@inject AuthenticationStateProvider AuthStateProvider
+@inject NavigationManager NavigationManager
+
+<PageTitle>Audit Log — Nutrir</PageTitle>
+
+<Breadcrumb Items="@(new[] { new BreadcrumbItem("Admin"), new BreadcrumbItem("Audit Log") })" />
+
+<div class="audit-log-page">
+    <div class="audit-log-header">
+        <h1 class="audit-log-title">Audit Log</h1>
+        <p class="audit-log-subtitle">Review system activity and changes across the application.</p>
+    </div>
+
+    <div class="audit-log-filters">
+        <div class="audit-log-filter-row">
+            <FormGroup Label="From" Id="filter-from">
+                <input type="date" id="filter-from" class="form-input"
+                       value="@_filterFrom?.ToString("yyyy-MM-dd")"
+                       @onchange="OnFromChanged" />
+            </FormGroup>
+
+            <FormGroup Label="To" Id="filter-to">
+                <input type="date" id="filter-to" class="form-input"
+                       value="@_filterTo?.ToString("yyyy-MM-dd")"
+                       @onchange="OnToChanged" />
+            </FormGroup>
+
+            <FormGroup Label="Action" Id="filter-action">
+                <FormSelect Id="filter-action"
+                            Value="@_filterAction"
+                            ValueChanged="OnActionChanged">
+                    <option value="">All Actions</option>
+                    @if (_distinctActions is not null)
+                    {
+                        @foreach (var action in _distinctActions)
+                        {
+                            <option value="@action">@action</option>
+                        }
+                    }
+                </FormSelect>
+            </FormGroup>
+
+            <FormGroup Label="Entity Type" Id="filter-entity-type">
+                <FormSelect Id="filter-entity-type"
+                            Value="@_filterEntityType"
+                            ValueChanged="OnEntityTypeChanged">
+                    <option value="">All Entity Types</option>
+                    @if (_distinctEntityTypes is not null)
+                    {
+                        @foreach (var entityType in _distinctEntityTypes)
+                        {
+                            <option value="@entityType">@entityType</option>
+                        }
+                    }
+                </FormSelect>
+            </FormGroup>
+
+            <FormGroup Label="Source" Id="filter-source">
+                <FormSelect Id="filter-source"
+                            Value="@_filterSource"
+                            ValueChanged="OnSourceChanged">
+                    <option value="">All Sources</option>
+                    <option value="Web">Web</option>
+                    <option value="Cli">CLI</option>
+                    <option value="AiAssistant">AI Assistant</option>
+                </FormSelect>
+            </FormGroup>
+
+            <FormGroup Label="Search" Id="filter-search">
+                <input type="text" id="filter-search" class="form-input"
+                       placeholder="Search logs..."
+                       value="@_filterSearch"
+                       @oninput="OnSearchInput" />
+            </FormGroup>
+
+            <div class="audit-log-filter-clear">
+                <button class="btn btn-ghost btn-sm" @onclick="ClearFilters">Clear</button>
+            </div>
+        </div>
+    </div>
+
+    @if (_isLoading)
+    {
+        <div class="table-card">
+            <p class="audit-log-loading">Loading audit logs...</p>
+        </div>
+    }
+    else if (_result is null || _result.Items.Count == 0)
+    {
+        <div class="table-card">
+            <div class="audit-log-empty">
+                <p class="audit-log-empty-title">No audit logs found</p>
+                <p class="audit-log-empty-desc">Try adjusting your filters or date range.</p>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="table-card">
+            <table class="audit-table" role="grid">
+                <thead>
+                    <tr>
+                        <th>Timestamp</th>
+                        <th>User</th>
+                        <th>Action</th>
+                        <th>Entity Type</th>
+                        <th class="col-entity-id">Entity ID</th>
+                        <th>Source</th>
+                        <th class="col-details">Details</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @{ var rowIndex = 0; }
+                    @foreach (var entry in _result.Items)
+                    {
+                        <tr style="animation-delay: @(rowIndex * 30)ms">
+                            <td class="audit-timestamp-cell">
+                                <div class="audit-timestamp-date">@entry.Timestamp.ToLocalTime().ToString("MMM d, yyyy")</div>
+                                <div class="audit-timestamp-time">@entry.Timestamp.ToLocalTime().ToString("h:mm:ss tt")</div>
+                            </td>
+                            <td>@entry.UserDisplayName</td>
+                            <td>
+                                <Badge Variant="@GetActionBadgeVariant(entry.Action)">@entry.Action</Badge>
+                            </td>
+                            <td>@entry.EntityType</td>
+                            <td class="col-entity-id">@(entry.EntityId ?? "—")</td>
+                            <td>@FormatSource(entry.Source)</td>
+                            <td class="col-details">
+                                <span class="audit-details-text" title="@entry.Details">@Truncate(entry.Details, 80)</span>
+                            </td>
+                        </tr>
+                        rowIndex++;
+                    }
+                </tbody>
+            </table>
+        </div>
+
+        <div class="audit-log-pagination">
+            <span class="audit-log-pagination-info">
+                Showing @((_result.Page - 1) * _result.PageSize + 1)–@Math.Min(_result.Page * _result.PageSize, _result.TotalCount) of @_result.TotalCount results
+            </span>
+
+            <div class="audit-log-pagination-buttons">
+                <button class="btn btn-ghost btn-sm"
+                        disabled="@(_result.Page <= 1)"
+                        @onclick="() => GoToPage(_result.Page - 1)">
+                    Previous
+                </button>
+
+                @foreach (var pageNum in GetPageNumbers())
+                {
+                    if (pageNum == -1)
+                    {
+                        <span class="audit-log-pagination-ellipsis">...</span>
+                    }
+                    else
+                    {
+                        <button class="btn btn-sm @(pageNum == _result.Page ? "btn-primary" : "btn-ghost")"
+                                @onclick="() => GoToPage(pageNum)">
+                            @pageNum
+                        </button>
+                    }
+                }
+
+                <button class="btn btn-ghost btn-sm"
+                        disabled="@(_result.Page >= TotalPages)"
+                        @onclick="() => GoToPage(_result.Page + 1)">
+                    Next
+                </button>
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    private AuditLogPageResult? _result;
+    private List<string>? _distinctActions;
+    private List<string>? _distinctEntityTypes;
+    private bool _isLoading = true;
+
+    private DateTime? _filterFrom;
+    private DateTime? _filterTo;
+    private string _filterAction = "";
+    private string _filterEntityType = "";
+    private string _filterSource = "";
+    private string _filterSearch = "";
+    private int _currentPage = 1;
+
+    private Timer? _debounceTimer;
+
+    private int TotalPages => _result is null || _result.PageSize == 0
+        ? 1
+        : (int)Math.Ceiling((double)_result.TotalCount / _result.PageSize);
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+            var userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "unknown";
+
+            var actionsTask = AuditLogService.GetDistinctActionsAsync();
+            var entityTypesTask = AuditLogService.GetDistinctEntityTypesAsync();
+            var logTask = AuditLogService.LogAsync(userId, "AuditLogViewed", "AuditLog");
+
+            await Task.WhenAll(actionsTask, entityTypesTask, logTask);
+
+            _distinctActions = actionsTask.Result;
+            _distinctEntityTypes = entityTypesTask.Result;
+
+            await LoadDataAsync();
+        }
+        catch
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task LoadDataAsync()
+    {
+        _isLoading = true;
+
+        try
+        {
+            AuditSource? source = string.IsNullOrEmpty(_filterSource)
+                ? null
+                : Enum.Parse<AuditSource>(_filterSource);
+
+            var request = new AuditLogQueryRequest(
+                Page: _currentPage,
+                PageSize: 25,
+                From: _filterFrom,
+                To: _filterTo,
+                Action: string.IsNullOrEmpty(_filterAction) ? null : _filterAction,
+                EntityType: string.IsNullOrEmpty(_filterEntityType) ? null : _filterEntityType,
+                Source: source,
+                SearchTerm: string.IsNullOrEmpty(_filterSearch) ? null : _filterSearch);
+
+            _result = await AuditLogService.QueryAsync(request);
+        }
+        catch
+        {
+            _result = null;
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task OnFromChanged(ChangeEventArgs e)
+    {
+        _filterFrom = DateTime.TryParse(e.Value?.ToString(), out var d) ? d : null;
+        _currentPage = 1;
+        await LoadDataAsync();
+    }
+
+    private async Task OnToChanged(ChangeEventArgs e)
+    {
+        _filterTo = DateTime.TryParse(e.Value?.ToString(), out var d) ? d : null;
+        _currentPage = 1;
+        await LoadDataAsync();
+    }
+
+    private async Task OnActionChanged(string value)
+    {
+        _filterAction = value;
+        _currentPage = 1;
+        await LoadDataAsync();
+    }
+
+    private async Task OnEntityTypeChanged(string value)
+    {
+        _filterEntityType = value;
+        _currentPage = 1;
+        await LoadDataAsync();
+    }
+
+    private async Task OnSourceChanged(string value)
+    {
+        _filterSource = value;
+        _currentPage = 1;
+        await LoadDataAsync();
+    }
+
+    private void OnSearchInput(ChangeEventArgs e)
+    {
+        _filterSearch = e.Value?.ToString() ?? "";
+        _debounceTimer?.Dispose();
+        _debounceTimer = new Timer(async _ =>
+        {
+            _currentPage = 1;
+            await InvokeAsync(async () =>
+            {
+                await LoadDataAsync();
+                StateHasChanged();
+            });
+        }, null, 300, Timeout.Infinite);
+    }
+
+    private async Task ClearFilters()
+    {
+        _filterFrom = null;
+        _filterTo = null;
+        _filterAction = "";
+        _filterEntityType = "";
+        _filterSource = "";
+        _filterSearch = "";
+        _currentPage = 1;
+        await LoadDataAsync();
+    }
+
+    private async Task GoToPage(int page)
+    {
+        if (page < 1 || page > TotalPages) return;
+        _currentPage = page;
+        await LoadDataAsync();
+    }
+
+    private List<int> GetPageNumbers()
+    {
+        var pages = new List<int>();
+        var total = TotalPages;
+        var current = _result?.Page ?? 1;
+
+        if (total <= 5)
+        {
+            for (var i = 1; i <= total; i++) pages.Add(i);
+            return pages;
+        }
+
+        pages.Add(1);
+
+        if (current > 3) pages.Add(-1); // ellipsis
+
+        var start = Math.Max(2, current - 1);
+        var end = Math.Min(total - 1, current + 1);
+
+        for (var i = start; i <= end; i++) pages.Add(i);
+
+        if (current < total - 2) pages.Add(-1); // ellipsis
+
+        pages.Add(total);
+
+        return pages;
+    }
+
+    private static BadgeVariant GetActionBadgeVariant(string action)
+    {
+        if (action.Contains("Create", StringComparison.OrdinalIgnoreCase) ||
+            action.Contains("Register", StringComparison.OrdinalIgnoreCase))
+            return BadgeVariant.Success;
+
+        if (action.Contains("Update", StringComparison.OrdinalIgnoreCase) ||
+            action.Contains("Edit", StringComparison.OrdinalIgnoreCase))
+            return BadgeVariant.Primary;
+
+        if (action.Contains("Delete", StringComparison.OrdinalIgnoreCase) ||
+            action.Contains("Remove", StringComparison.OrdinalIgnoreCase) ||
+            action.Contains("SoftDelete", StringComparison.OrdinalIgnoreCase))
+            return BadgeVariant.Error;
+
+        if (action.Contains("Login", StringComparison.OrdinalIgnoreCase) ||
+            action.Contains("Logout", StringComparison.OrdinalIgnoreCase) ||
+            action.Contains("Auth", StringComparison.OrdinalIgnoreCase))
+            return BadgeVariant.Accent;
+
+        return BadgeVariant.Secondary;
+    }
+
+    private static string FormatSource(AuditSource source) => source switch
+    {
+        AuditSource.Web => "Web",
+        AuditSource.Cli => "CLI",
+        AuditSource.AiAssistant => "AI Assistant",
+        _ => source.ToString()
+    };
+
+    private static string Truncate(string? text, int maxLength)
+    {
+        if (string.IsNullOrEmpty(text)) return "—";
+        return text.Length <= maxLength ? text : text[..maxLength] + "...";
+    }
+
+    public void Dispose()
+    {
+        _debounceTimer?.Dispose();
+    }
+}

--- a/src/Nutrir.Web/Components/Pages/Admin/AuditLog.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Admin/AuditLog.razor.css
@@ -1,0 +1,237 @@
+/* Page layout */
+.audit-log-page {
+    max-width: 1200px;
+    padding: var(--space-8);
+}
+
+.audit-log-header {
+    margin-bottom: var(--space-6);
+}
+
+.audit-log-title {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: var(--space-2);
+}
+
+.audit-log-subtitle {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+}
+
+/* Filter toolbar */
+.audit-log-filters {
+    margin-bottom: var(--space-6);
+}
+
+.audit-log-filter-row {
+    display: flex;
+    gap: var(--space-4);
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+
+.audit-log-filter-row ::deep .form-group {
+    min-width: 140px;
+    flex: 1;
+}
+
+.audit-log-filter-clear {
+    padding-bottom: var(--space-1);
+}
+
+/* Table card wrapper (per data-tables.md) */
+.table-card {
+    background: white;
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--color-border);
+    overflow: hidden;
+}
+
+/* Table */
+.audit-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.audit-table thead th {
+    text-align: left;
+    padding: var(--space-3) var(--space-4);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider);
+    color: var(--color-text-muted);
+    background: var(--color-bg-alt);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.audit-table thead th:first-child {
+    padding-left: var(--space-6);
+}
+
+.audit-table thead th:last-child {
+    padding-right: var(--space-6);
+}
+
+.audit-table tbody tr {
+    animation: rowFadeIn 0.3s ease both;
+    transition: background-color 0.15s ease;
+}
+
+.audit-table tbody tr:hover {
+    background-color: var(--color-bg-alt);
+}
+
+.audit-table tbody td {
+    padding: var(--space-3) var(--space-4);
+    font-size: var(--text-sm);
+    color: var(--color-text);
+    border-bottom: 1px solid var(--color-border);
+    vertical-align: top;
+}
+
+.audit-table tbody td:first-child {
+    padding-left: var(--space-6);
+}
+
+.audit-table tbody td:last-child {
+    padding-right: var(--space-6);
+}
+
+.audit-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+/* Staggered row animation */
+@keyframes rowFadeIn {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Timestamp stacked cell */
+.audit-timestamp-cell {
+    white-space: nowrap;
+}
+
+.audit-timestamp-date {
+    font-weight: 500;
+    font-size: var(--text-sm);
+}
+
+.audit-timestamp-time {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+}
+
+/* Details truncation */
+.audit-details-text {
+    display: inline-block;
+    max-width: 240px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+}
+
+/* Loading state */
+.audit-log-loading {
+    padding: var(--space-8);
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
+}
+
+/* Empty state */
+.audit-log-empty {
+    padding: var(--space-8);
+    text-align: center;
+}
+
+.audit-log-empty-title {
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: var(--space-1);
+}
+
+.audit-log-empty-desc {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+}
+
+/* Pagination */
+.audit-log-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: var(--space-4);
+    gap: var(--space-4);
+    flex-wrap: wrap;
+}
+
+.audit-log-pagination-info {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+}
+
+.audit-log-pagination-buttons {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.audit-log-pagination-ellipsis {
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+}
+
+/* Responsive: hide Entity ID at <= 860px */
+@media (max-width: 860px) {
+    .col-entity-id {
+        display: none;
+    }
+
+    .audit-log-filter-row {
+        gap: var(--space-3);
+    }
+
+    .audit-log-filter-row ::deep .form-group {
+        min-width: 120px;
+    }
+}
+
+/* Responsive: hide Details at <= 600px */
+@media (max-width: 600px) {
+    .col-details {
+        display: none;
+    }
+
+    .audit-log-page {
+        padding: var(--space-4);
+    }
+
+    .audit-table tbody td,
+    .audit-table thead th {
+        padding: var(--space-2) var(--space-3);
+    }
+
+    .audit-table tbody td:first-child,
+    .audit-table thead th:first-child {
+        padding-left: var(--space-3);
+    }
+
+    .audit-table tbody td:last-child,
+    .audit-table thead th:last-child {
+        padding-right: var(--space-3);
+    }
+
+    .audit-log-pagination {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds web UI audit log viewer at `/admin/audit-log` with server-side pagination, filtering (date range, action, entity type, source, free-text search), and batch user display name resolution
- Introduces first server-side pagination pattern in the app using `Skip`/`Take` with `CountAsync`
- Adds sidebar navigation entry for Audit Log in the admin section

## Test plan
- [ ] Navigate to `/admin/audit-log` as Admin or Nutritionist — page loads with audit log entries
- [ ] Verify filter dropdowns (Action, Entity Type, Source) are populated from actual DB values
- [ ] Test date range filtering with From/To date pickers
- [ ] Test free-text search with 300ms debounce
- [ ] Verify pagination controls (Previous/Next/page numbers) work correctly
- [ ] Verify responsive layout: Entity ID hidden at ≤860px, Details hidden at ≤600px
- [ ] Verify unauthorized users (non-Admin/Nutritionist) cannot access the page
- [ ] Confirm the page logs its own access as `AuditLogViewed` action

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)