### PR TITLE
Fix meal plan detail header layout wrapping

### DIFF
--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor.css
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor.css
@@ -64,9 +64,8 @@
 /* ── Hero Header ─────────────────────────────────────── */
 .hero {
     display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: var(--space-6);
+    flex-direction: column;
+    gap: var(--space-4);
     padding: var(--space-6);
 }
 
@@ -91,6 +90,7 @@
 
 .hero-info {
     min-width: 0;
+    flex: 1;
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
@@ -171,8 +171,8 @@
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    flex-shrink: 0;
     flex-wrap: wrap;
+    padding-left: calc(56px + var(--space-4));
 }
 
 /* ── Section Headers ─────────────────────────────────── */
@@ -380,17 +380,6 @@
     font-size: var(--text-xs);
     color: var(--color-text-muted);
     padding: 0 var(--space-2);
-}
-
-/* ── Responsive: Tablet ──────────────────────────────── */
-@media (max-width: 768px) {
-    .hero {
-        flex-direction: column;
-    }
-
-    .hero-actions {
-        padding-left: calc(56px + var(--space-4));
-    }
 }
 
 /* ── Responsive: Mobile ──────────────────────────────── */


### PR DESCRIPTION
## Summary
- Restructured the hero section from horizontal `space-between` flex layout to vertical column layout, so action buttons no longer steal horizontal space from the title and metadata
- Added `padding-left` on `.hero-actions` to align buttons with the content area (past the icon)
- Added `flex: 1` on `.hero-info` so the identity section fills available width
- Removed the redundant tablet breakpoint (hero is now column layout by default)

Closes #70

## Test plan
- [ ] Verify title displays without awkward mid-word wrapping at desktop widths
- [ ] Verify client name and date range display inline on one row
- [ ] Verify macro targets (kcal, P, C, F) display inline on one row  
- [ ] Verify action buttons appear below the title/meta area, aligned with content
- [ ] Verify layout remains readable on narrow/mobile viewports (centered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)