### PR TITLE
Set default 30-day filter range on audit log page

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Admin/AuditLog.razor
+++ b/src/Nutrir.Web/Components/Pages/Admin/AuditLog.razor
@@ -188,8 +188,8 @@
     private List<string>? _distinctEntityTypes;
     private bool _isLoading = true;
 
-    private DateTime? _filterFrom;
-    private DateTime? _filterTo;
+    private DateTime? _filterFrom = DateTime.Today.AddDays(-30);
+    private DateTime? _filterTo = DateTime.Today;
     private string _filterAction = "";
     private string _filterEntityType = "";
     private string _filterSource = "";
@@ -310,8 +310,8 @@
 
     private async Task ClearFilters()
     {
-        _filterFrom = null;
-        _filterTo = null;
+        _filterFrom = DateTime.Today.AddDays(-30);
+        _filterTo = DateTime.Today;
         _filterAction = "";
         _filterEntityType = "";
         _filterSource = "";


### PR DESCRIPTION
## Summary
- Default `_filterFrom` to 30 days ago and `_filterTo` to today on the audit log page
- "Clear Filters" now resets to the 30-day default instead of null/unbounded
- No backend changes needed — purely a UI default change

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)