### PR TITLE
fix: restore AI panel open state on page reload

### DIFF
--- a/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor
+++ b/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor
@@ -189,6 +189,13 @@
             try
             {
                 _isWide = await JS.InvokeAsync<bool>("aiPanel.getStoredWideState");
+
+                var storedOpen = await JS.InvokeAsync<bool>("aiPanel.getStoredState");
+                if (storedOpen)
+                {
+                    _isOpen = true;
+                    PanelState.SetOpen(true);
+                }
             }
             catch (JSException) { }
 

--- a/src/Nutrir.Web/Components/Layout/AiPanelState.cs
+++ b/src/Nutrir.Web/Components/Layout/AiPanelState.cs
@@ -22,4 +22,11 @@ public class AiPanelState
         IsOpen = false;
         OnToggle?.Invoke();
     }
+
+    public void SetOpen(bool isOpen)
+    {
+        if (IsOpen == isOpen) return;
+        IsOpen = isOpen;
+        OnToggle?.Invoke();
+    }
 }


### PR DESCRIPTION
## Summary

- Restore the AI Assistant panel's open/closed state from `localStorage` on page reload, matching the existing pattern used for the wide state
- Add `SetOpen(bool)` method to `AiPanelState` to allow restoring state without triggering a toggle cycle
- Conversation history was already loading correctly — it just wasn't visible because the panel always defaulted to closed on new circuits

## Test plan

- [ ] Open the AI panel, send a message, refresh the page — panel should reopen with conversation history visible
- [ ] Close the AI panel, refresh the page — panel should remain closed
- [ ] SPA navigation (clicking links) should continue working as before — panel stays open between navigations
- [ ] Wide state should continue to persist independently

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)