### PR TITLE
feat: add grant/re-grant consent flow for existing clients

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
@@ -7,10 +7,13 @@
 @using System.Security.Claims
 @using Nutrir.Core.DTOs
 @using Nutrir.Core.Interfaces
+@using Nutrir.Core.Models
 @using Nutrir.Web.Components.UI
 @attribute [Authorize(Roles = "Admin,Nutritionist,Assistant")]
 @inject IClientService ClientService
 @inject IConsentService ConsentService
+@inject IConsentFormService ConsentFormService
+@inject IConsentFormTemplate ConsentFormTemplate
 @inject IUserManagementService UserManagementService
 @inject NavigationManager NavigationManager
 
@@ -161,6 +164,36 @@
                             }
                         </div>
                     </div>
+
+                    @if (!_client!.ConsentGiven)
+                    {
+                        <div class="consent-grant-section">
+                            <div class="section-header">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+                                </svg>
+                                <span class="section-header-label">Grant Consent</span>
+                            </div>
+                            <div class="consent-grant-body">
+                                <p class="consent-grant-desc">Review the consent form below, then confirm that the client has provided their informed consent.</p>
+
+                                <ConsentFormReview Content="@_consentContent" />
+
+                                <div class="consent-grant-actions">
+                                    <Button Variant="ButtonVariant.Primary" OnClick="GrantConsent" Disabled="@_isGranting">
+                                        @if (_isGranting)
+                                        {
+                                            <span>Granting Consent...</span>
+                                        }
+                                        else
+                                        {
+                                            <span>Grant Consent</span>
+                                        }
+                                    </Button>
+                                </div>
+                            </div>
+                        </div>
+                    }
                 </div>
 
                 @if (!string.IsNullOrEmpty(_errorMessage))
@@ -233,6 +266,15 @@
                 o => o.Value == _client.PrimaryNutritionistId);
             _nutritionistDisplayText = currentNutritionist?.Text
                 ?? _client.PrimaryNutritionistName;
+
+            if (!_client.ConsentGiven)
+            {
+                var practitionerName = _nutritionistDisplayText ?? "(Practitioner)";
+                _consentContent = ConsentFormTemplate.Generate(
+                    $"{_client.FirstName} {_client.LastName}",
+                    practitionerName,
+                    DateTime.UtcNow);
+            }
         }
 
         _isLoading = false;
@@ -244,6 +286,49 @@
     }
 
     private bool _isWithdrawing;
+    private bool _isGranting;
+    private ConsentFormContent? _consentContent;
+
+    private async Task GrantConsent()
+    {
+        _isGranting = true;
+        _errorMessage = null;
+
+        try
+        {
+            var authState = await AuthState;
+            var userId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+            {
+                _errorMessage = "Unable to identify the current user. Please sign out and back in.";
+                return;
+            }
+
+            // Regenerate consent content with current timestamp for accuracy
+            var practitionerName = _nutritionistDisplayText ?? "(Practitioner)";
+            _consentContent = ConsentFormTemplate.Generate(
+                $"{_client!.FirstName} {_client.LastName}",
+                practitionerName,
+                DateTime.UtcNow);
+
+            await ConsentFormService.RecordDigitalSignatureAsync(Id, userId);
+
+            // Reload client to reflect updated consent status
+            _client = await ClientService.GetByIdAsync(Id);
+            if (_client is null)
+            {
+                _errorMessage = "Client could not be reloaded. Please refresh the page.";
+            }
+        }
+        catch
+        {
+            _errorMessage = "An error occurred while granting consent. Please try again.";
+        }
+        finally
+        {
+            _isGranting = false;
+        }
+    }
 
     private async Task WithdrawConsent()
     {

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor.css
@@ -178,6 +178,34 @@
     justify-content: center;
 }
 
+/* ── Grant Consent Section ────────────────────────────── */
+.consent-grant-section {
+    border-top: 1px solid var(--color-border);
+}
+
+.consent-grant-section .section-header {
+    border-radius: 0;
+}
+
+.consent-grant-body {
+    padding: var(--space-5) var(--space-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+}
+
+.consent-grant-desc {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+}
+
+.consent-grant-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+}
+
 /* ── Section Fade-In Animation ────────────────────────── */
 @keyframes sectionFadeIn {
     from { opacity: 0; transform: translateY(8px); }


### PR DESCRIPTION
## Summary

- Adds a "Grant Consent" section to `ClientEdit.razor` that appears when a client has `ConsentGiven == false`
- Shows the full consent form via `ConsentFormReview` component before allowing consent to be recorded
- Calls `IConsentFormService.RecordDigitalSignatureAsync` which creates the consent form document, marks it as digitally signed, calls `GrantConsentAsync` with the current policy version, and logs the audit trail
- Works for both first-time granting and re-granting (after withdrawal) scenarios

## Test plan

- [ ] Navigate to a client without consent → verify "Grant Consent" section appears with consent form review
- [ ] Expand consent form → verify full consent text is displayed
- [ ] Click "Grant Consent" → verify consent badge changes to "Consent Given" with date and policy version
- [ ] Navigate to client detail page → verify consent badge shows updated status
- [ ] Check audit log → verify `ConsentGiven` event was created
- [ ] Withdraw consent, then re-grant → verify the full flow works end-to-end
- [ ] Verify "Grant Consent" section is hidden when client already has consent

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)