### PR TITLE
feat: enrich AI tool confirmation with entity names

### DIFF
--- a/src/Nutrir.Infrastructure/Services/AiAgentService.cs
+++ b/src/Nutrir.Infrastructure/Services/AiAgentService.cs
@@ -255,7 +255,7 @@ public class AiAgentService : IAiAgentService
                     {
                         // Write tool — requires user confirmation
                         var inputElement = JsonSerializer.SerializeToElement(toolUse.Input);
-                        var description = AiToolExecutor.BuildConfirmationDescription(toolUse.Name, inputElement);
+                        var description = await _toolExecutor.BuildConfirmationDescriptionAsync(toolUse.Name, inputElement);
 
                         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                         _pendingConfirmations[toolUse.ID] = tcs;

--- a/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor.css
+++ b/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor.css
@@ -457,6 +457,7 @@
     display: flex;
     align-items: flex-start;
     gap: var(--space-1);
+    word-break: break-word;
 }
 
 .cc-ai-confirmation-icon {


### PR DESCRIPTION
## Summary
- Converts `BuildConfirmationDescription` from a static sync method to an async instance method that resolves entity names from the database
- Confirmation prompts now show human-readable context: `update client "Jane Smith" (#21) — changing: date_of_birth, notes` instead of `update client #21`
- Update operations list the fields being changed (extracted from the tool input)
- All lookups wrapped in try/catch — gracefully falls back to previous ID-only format on failure
- Added `word-break: break-word` to confirmation description CSS for longer text

## Test plan
- [ ] `dotnet build` passes (verified)
- [ ] Docker compose up, open AI assistant panel
- [ ] Ask AI to update a client → confirmation shows client name + changed fields
- [ ] Ask AI to delete an appointment → confirmation shows client name + date
- [ ] Ask AI to archive a meal plan → confirmation shows plan title
- [ ] Ask AI to achieve a goal → confirmation shows goal title
- [ ] Ask AI to deactivate a user → confirmation shows display name
- [ ] Verify Allow/Deny still works correctly
- [ ] Verify elevated tier (user management) still shows warning styling

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)