### PR TITLE
Fix AI panel scrollbar overlapping main page scrollbar

### DIFF
--- a/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor
+++ b/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor
@@ -196,9 +196,10 @@
 
     protected override void OnInitialized()
     {
-        PanelState.OnToggle += OnPanelToggle;
+        PanelState.OnChange += OnPanelToggle;
         Navigation.LocationChanged += OnLocationChanged;
         _isOpen = PanelState.IsOpen;
+        _isWide = PanelState.IsWide;
         AiAgent.SetPageContext(Navigation.Uri);
     }
 
@@ -211,6 +212,7 @@
             try
             {
                 _isWide = await JS.InvokeAsync<bool>("aiPanel.getStoredWideState");
+                PanelState.SetWide(_isWide);
 
                 var storedOpen = await JS.InvokeAsync<bool>("aiPanel.getStoredState");
                 if (storedOpen)
@@ -273,6 +275,7 @@
     private void OnPanelToggle()
     {
         _isOpen = PanelState.IsOpen;
+        _isWide = PanelState.IsWide;
         InvokeAsync(async () =>
         {
             StateHasChanged();
@@ -298,6 +301,7 @@
     private async Task ToggleWide()
     {
         _isWide = !_isWide;
+        PanelState.SetWide(_isWide);
         if (_jsInitialized)
         {
             try { await JS.InvokeVoidAsync("aiPanel.saveWideState", _isWide); }
@@ -549,7 +553,7 @@
 
     public void Dispose()
     {
-        PanelState.OnToggle -= OnPanelToggle;
+        PanelState.OnChange -= OnPanelToggle;
         Navigation.LocationChanged -= OnLocationChanged;
         _debounceTimer?.Dispose();
         _streamCts?.Cancel();
@@ -558,7 +562,7 @@
 
     public ValueTask DisposeAsync()
     {
-        PanelState.OnToggle -= OnPanelToggle;
+        PanelState.OnChange -= OnPanelToggle;
         Navigation.LocationChanged -= OnLocationChanged;
         _debounceTimer?.Dispose();
         _streamCts?.Cancel();

--- a/src/Nutrir.Web/Components/Layout/AiPanelState.cs
+++ b/src/Nutrir.Web/Components/Layout/AiPanelState.cs
@@ -7,26 +7,34 @@ namespace Nutrir.Web.Components.Layout;
 public class AiPanelState
 {
     public bool IsOpen { get; private set; }
+    public bool IsWide { get; private set; }
 
-    public event Action? OnToggle;
+    public event Action? OnChange;
 
     public void Toggle()
     {
         IsOpen = !IsOpen;
-        OnToggle?.Invoke();
+        OnChange?.Invoke();
     }
 
     public void Close()
     {
         if (!IsOpen) return;
         IsOpen = false;
-        OnToggle?.Invoke();
+        OnChange?.Invoke();
     }
 
     public void SetOpen(bool isOpen)
     {
         if (IsOpen == isOpen) return;
         IsOpen = isOpen;
-        OnToggle?.Invoke();
+        OnChange?.Invoke();
+    }
+
+    public void SetWide(bool isWide)
+    {
+        if (IsWide == isWide) return;
+        IsWide = isWide;
+        OnChange?.Invoke();
     }
 }

--- a/src/Nutrir.Web/Components/Layout/AiToggleButton.razor
+++ b/src/Nutrir.Web/Components/Layout/AiToggleButton.razor
@@ -14,11 +14,11 @@
 @code {
     protected override void OnInitialized()
     {
-        PanelState.OnToggle += StateHasChanged;
+        PanelState.OnChange += StateHasChanged;
     }
 
     public void Dispose()
     {
-        PanelState.OnToggle -= StateHasChanged;
+        PanelState.OnChange -= StateHasChanged;
     }
 }

--- a/src/Nutrir.Web/Components/Layout/MainLayout.razor
+++ b/src/Nutrir.Web/Components/Layout/MainLayout.razor
@@ -1,8 +1,10 @@
 @inherits LayoutComponentBase
+@implements IDisposable
+@inject AiPanelState PanelState
 
 <div class="cc-layout">
     <IconRailSidebar />
-    <div class="cc-main">
+    <div class="cc-main @(PanelState.IsOpen ? "cc-main--ai-open" : "") @(PanelState.IsOpen && PanelState.IsWide ? "cc-main--ai-wide" : "")">
         <TopBar />
         <div class="cc-body">
             @Body
@@ -18,3 +20,20 @@
     <a href="." class="reload">Reload</a>
     <span class="dismiss">&#x1f5d9;</span>
 </div>
+
+@code {
+    protected override void OnInitialized()
+    {
+        PanelState.OnChange += OnPanelChanged;
+    }
+
+    private void OnPanelChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        PanelState.OnChange -= OnPanelChanged;
+    }
+}

--- a/src/Nutrir.Web/wwwroot/css/layout.css
+++ b/src/Nutrir.Web/wwwroot/css/layout.css
@@ -157,6 +157,15 @@
   display: flex;
   flex-direction: column;
   background: var(--color-bg);
+  transition: margin-right var(--duration-normal) var(--ease-default);
+}
+
+.cc-main--ai-open {
+  margin-right: 400px;
+}
+
+.cc-main--ai-wide {
+  margin-right: 700px;
 }
 
 
@@ -1018,6 +1027,13 @@
 
   .dash-actions {
     flex-wrap: wrap;
+  }
+
+  .cc-main--ai-open,
+  .cc-main--ai-wide {
+    margin-right: 0;
+    pointer-events: none;
+    user-select: none;
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds right margin to `.cc-main` when AI panel is open (400px default, 700px wide), pushing the main content scrollbar left so it doesn't overlap the panel's scrollbar
- Shares wide-mode state via `AiPanelState` service so `MainLayout` can respond to both open/close and wide/narrow changes
- On mobile (≤768px), disables main content interaction when panel is open since the panel is full-width
- Renames `AiPanelState.OnToggle` → `OnChange` to reflect it now covers both open and wide state changes

## Test plan

- [ ] Open AI panel on a page with scrollable content — main page scrollbar should shift left, not overlap panel scrollbar
- [ ] Toggle wide mode — main content margin should adjust from 400px to 700px
- [ ] Close panel — main content should return to full width with smooth transition
- [ ] Test on mobile viewport — panel should be full-width, main content should be non-interactive behind it
- [ ] Verify no layout shift or jank when opening/closing panel

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)