### PR TITLE
feat: add column sorting and consent status filtering to clients table

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Clients/ClientList.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientList.razor
@@ -27,8 +27,8 @@
         </Button>
     </div>
 
-    <div class="toolbar" role="search">
-        <div class="search-wrapper">
+    <div class="toolbar" role="toolbar" aria-label="Client list controls">
+        <div class="search-wrapper" role="search">
             <svg class="search-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="7" cy="7" r="4.5"/>
                 <path d="m10.5 10.5 3 3"/>
@@ -43,8 +43,17 @@
                    @oninput="OnSearchInput" />
         </div>
 
+        <div class="filter-group">
+            <label for="consent-filter" class="filter-label">Consent</label>
+            <select id="consent-filter" class="filter-select" value="@_consentFilter" @onchange="OnConsentFilterChanged">
+                <option value="">All</option>
+                <option value="Given">Given</option>
+                <option value="Pending">Pending</option>
+            </select>
+        </div>
+
         <span class="client-count" aria-live="polite">
-            <strong>@(_clients?.Count ?? 0)</strong> clients
+            <strong>@(FilteredClients.Count)</strong> clients
         </span>
     </div>
 
@@ -77,22 +86,50 @@
             </div>
         </div>
     }
+    else if (FilteredClients.Count == 0)
+    {
+        <div class="table-card">
+            <div class="empty-state" role="status">
+                <svg class="empty-state-icon" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="32" cy="24" r="10" stroke-opacity="0.5"/>
+                    <path d="M14 54c0-8 7-14 18-14s18 6 18 14" stroke-opacity="0.5"/>
+                    <path d="M44 12l8 8M52 12l-8 8" stroke-opacity="0.35"/>
+                </svg>
+                <p class="empty-state-title">No matching clients</p>
+                <p class="empty-state-desc">
+                    <span>Try adjusting your filter or search criteria.</span>
+                </p>
+            </div>
+        </div>
+    }
     else
     {
         <div class="table-card">
             <table class="clients-table" role="grid">
                 <thead>
                     <tr>
-                        <th scope="col" class="col-client">Client</th>
+                        <th scope="col" class="col-client sortable" aria-sort="@GetAriaSort("Name")" tabindex="0"
+                            @onclick="@(() => OnSortColumn("Name"))" @onkeydown="@(e => OnSortKeyDown(e, "Name"))">
+                            Client <span class="sort-indicator" aria-hidden="true">@GetSortIcon("Name")</span>
+                        </th>
                         <th scope="col" class="col-phone">Phone</th>
-                        <th scope="col" class="col-nutritionist">Nutritionist</th>
-                        <th scope="col" class="col-consent">Consent</th>
-                        <th scope="col" class="col-date">Created</th>
+                        <th scope="col" class="col-nutritionist sortable" aria-sort="@GetAriaSort("Nutritionist")" tabindex="0"
+                            @onclick="@(() => OnSortColumn("Nutritionist"))" @onkeydown="@(e => OnSortKeyDown(e, "Nutritionist"))">
+                            Nutritionist <span class="sort-indicator" aria-hidden="true">@GetSortIcon("Nutritionist")</span>
+                        </th>
+                        <th scope="col" class="col-consent sortable" aria-sort="@GetAriaSort("Consent")" tabindex="0"
+                            @onclick="@(() => OnSortColumn("Consent"))" @onkeydown="@(e => OnSortKeyDown(e, "Consent"))">
+                            Consent <span class="sort-indicator" aria-hidden="true">@GetSortIcon("Consent")</span>
+                        </th>
+                        <th scope="col" class="col-date sortable" aria-sort="@GetAriaSort("Created")" tabindex="0"
+                            @onclick="@(() => OnSortColumn("Created"))" @onkeydown="@(e => OnSortKeyDown(e, "Created"))">
+                            Created <span class="sort-indicator" aria-hidden="true">@GetSortIcon("Created")</span>
+                        </th>
                         <th scope="col"><span class="sr-only">Actions</span></th>
                     </tr>
                 </thead>
                 <tbody>
-                    @foreach (var client in _clients)
+                    @foreach (var client in FilteredClients)
                     {
                         <tr>
                             <td>
@@ -141,6 +178,46 @@
     private bool _isLoading = true;
     private System.Threading.Timer? _debounceTimer;
 
+    private string? _sortColumn;
+    private bool _sortAscending = true;
+    private string _consentFilter = "";
+
+    private IReadOnlyList<ClientDto> FilteredClients
+    {
+        get
+        {
+            if (_clients is null || _clients.Count == 0)
+                return Array.Empty<ClientDto>();
+
+            IEnumerable<ClientDto> result = _clients;
+
+            // Apply consent filter
+            if (_consentFilter == "Given")
+                result = result.Where(c => c.ConsentGiven);
+            else if (_consentFilter == "Pending")
+                result = result.Where(c => !c.ConsentGiven);
+
+            // Apply sort
+            if (!string.IsNullOrEmpty(_sortColumn))
+            {
+                result = (_sortColumn, _sortAscending) switch
+                {
+                    ("Name", true) => result.OrderBy(c => c.LastName).ThenBy(c => c.FirstName),
+                    ("Name", false) => result.OrderByDescending(c => c.LastName).ThenByDescending(c => c.FirstName),
+                    ("Nutritionist", true) => result.OrderBy(c => c.PrimaryNutritionistName ?? string.Empty),
+                    ("Nutritionist", false) => result.OrderByDescending(c => c.PrimaryNutritionistName ?? string.Empty),
+                    ("Consent", true) => result.OrderBy(c => c.ConsentGiven),
+                    ("Consent", false) => result.OrderByDescending(c => c.ConsentGiven),
+                    ("Created", true) => result.OrderBy(c => c.CreatedAt),
+                    ("Created", false) => result.OrderByDescending(c => c.CreatedAt),
+                    _ => result
+                };
+            }
+
+            return result.ToList();
+        }
+    }
+
     protected override async Task OnInitializedAsync()
     {
         await LoadClientsAsync();
@@ -156,6 +233,8 @@
     private void OnSearchInput(ChangeEventArgs e)
     {
         _searchTerm = e.Value?.ToString();
+        _sortColumn = null;
+        _sortAscending = true;
         _debounceTimer?.Dispose();
         _debounceTimer = new System.Threading.Timer(async _ =>
         {
@@ -165,6 +244,52 @@
                 StateHasChanged();
             });
         }, null, 300, Timeout.Infinite);
+    }
+
+    private void OnSortColumn(string column)
+    {
+        if (_sortColumn == column)
+        {
+            if (_sortAscending)
+            {
+                _sortAscending = false;
+            }
+            else
+            {
+                _sortColumn = null;
+                _sortAscending = true;
+            }
+        }
+        else
+        {
+            _sortColumn = column;
+            _sortAscending = true;
+        }
+    }
+
+    private void OnSortKeyDown(KeyboardEventArgs e, string column)
+    {
+        if (e.Key == "Enter" || e.Key == " ")
+            OnSortColumn(column);
+    }
+
+    private void OnConsentFilterChanged(ChangeEventArgs e)
+    {
+        _consentFilter = e.Value?.ToString() ?? "";
+    }
+
+    private string GetAriaSort(string column)
+    {
+        if (_sortColumn != column)
+            return "none";
+        return _sortAscending ? "ascending" : "descending";
+    }
+
+    private string GetSortIcon(string column)
+    {
+        if (_sortColumn != column)
+            return "\u2195"; // ↕ up-down arrow (unsorted)
+        return _sortAscending ? "\u2191" : "\u2193"; // ↑ or ↓
     }
 
     private static string GetInitials(ClientDto client)

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientList.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientList.razor.css
@@ -65,6 +65,46 @@
     box-shadow: 0 0 0 3px var(--color-primary-muted);
 }
 
+/* ── Filter ─────────────────────────────────────────── */
+.filter-group {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.filter-label {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider);
+    color: var(--color-text-muted);
+    white-space: nowrap;
+}
+
+.filter-select {
+    padding: var(--space-2) var(--space-3);
+    padding-right: var(--space-8);
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    color: var(--color-text);
+    background: var(--color-bg-input);
+    border: 1px solid var(--color-border-input);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none' stroke='%236b7280' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m3 4.5 3 3 3-3'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right var(--space-2) center;
+    transition: border-color var(--duration-fast) var(--ease-default),
+                box-shadow var(--duration-fast) var(--ease-default);
+}
+
+.filter-select:focus {
+    outline: none;
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 0 3px var(--color-primary-muted);
+}
+
 .client-count {
     font-size: var(--text-sm);
     color: var(--color-text-muted);
@@ -139,6 +179,39 @@
 .clients-table thead th.col-client {
     /* Align with name text: space-6 (24px) + avatar (38px) + gap space-3 (12px) = 74px */
     padding-left: 74px;
+}
+
+/* ── Sortable Headers ───────────────────────────────── */
+.clients-table thead th.sortable {
+    cursor: pointer;
+    transition: color var(--duration-fast) var(--ease-default);
+}
+
+.clients-table thead th.sortable:hover,
+.clients-table thead th.sortable:focus-visible {
+    color: var(--color-text);
+}
+
+.clients-table thead th.sortable:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
+}
+
+.sort-indicator {
+    display: inline-block;
+    margin-left: var(--space-1);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    transition: color var(--duration-fast) var(--ease-default);
+}
+
+.clients-table thead th.sortable:hover .sort-indicator {
+    color: var(--color-primary);
+}
+
+.clients-table thead th.sortable[aria-sort="ascending"] .sort-indicator,
+.clients-table thead th.sortable[aria-sort="descending"] .sort-indicator {
+    color: var(--color-primary);
 }
 
 .clients-table thead th:last-child {
@@ -369,7 +442,11 @@
 
     .search-wrapper {
         max-width: none;
-        flex: 1 1 100%;
+        flex: 1 1 auto;
+    }
+
+    .filter-group {
+        margin-left: auto;
     }
 }
 


### PR DESCRIPTION
## Summary

- Added clickable column sorting (ascending → descending → default cycle) for Client name, Nutritionist, Consent status, and Created date columns
- Added consent status filter dropdown (All / Given / Pending) in the toolbar next to the search input
- Sort and filter work together with existing search — consent filter persists across search changes, sort resets on new search
- Client count reflects filtered results, not total
- Keyboard accessible: sortable headers have `tabindex="0"`, `@onkeydown`, `aria-sort`, and focus-visible styles
- All client-side — no API/service changes needed

Closes #77

## Test plan

- [ ] Click each sortable column header — verify ascending → descending → default cycle
- [ ] Verify sort indicator arrow shows correct direction and highlights in primary color
- [ ] Select "Given" and "Pending" from consent filter — verify table filters correctly
- [ ] Combine search + filter — verify both apply together
- [ ] Type in search — verify sort resets but consent filter persists
- [ ] Tab to column headers — verify focus ring appears and Enter/Space activates sort
- [ ] Test at 860px width — Phone and Nutritionist columns should hide
- [ ] Test at 600px width — Consent and Created columns should hide
- [ ] Verify "No matching clients" empty state appears when filter produces zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)