### PR TITLE
feat: embedded entity detail cards in AI confirmation dialogs

### DIFF
--- a/src/Nutrir.Core/Interfaces/IAiAgentService.cs
+++ b/src/Nutrir.Core/Interfaces/IAiAgentService.cs
@@ -2,11 +2,22 @@ namespace Nutrir.Core.Interfaces;
 
 public enum ConfirmationTier { Standard, Elevated }
 
+public record FieldChange(string FieldLabel, string? CurrentValue, string? ProposedValue);
+
+public record EntityContext(
+    string EntityType,
+    string OperationType,
+    int? EntityId,
+    string? DisplayName,
+    List<FieldChange>? Fields
+);
+
 public record ToolConfirmationRequest(
     string ToolCallId,
     string ToolName,
     string Description,
-    ConfirmationTier Tier
+    ConfirmationTier Tier,
+    EntityContext? Entity = null
 );
 
 public record AgentStreamEvent

--- a/src/Nutrir.Infrastructure/Services/AiAgentService.cs
+++ b/src/Nutrir.Infrastructure/Services/AiAgentService.cs
@@ -271,7 +271,7 @@ public class AiAgentService : IAiAgentService
                     {
                         // Write tool — requires user confirmation
                         var inputElement = JsonSerializer.SerializeToElement(toolUse.Input);
-                        var description = await _toolExecutor.BuildConfirmationDescriptionAsync(toolUse.Name, inputElement);
+                        var (description, entityContext) = await _toolExecutor.BuildConfirmationDescriptionAsync(toolUse.Name, inputElement);
 
                         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                         _pendingConfirmations[toolUse.ID] = tcs;
@@ -283,7 +283,7 @@ public class AiAgentService : IAiAgentService
                         {
                             ToolName = toolUse.Name,
                             ConfirmationRequest = new ToolConfirmationRequest(
-                                toolUse.ID, toolUse.Name, description, confirmationTier.Value)
+                                toolUse.ID, toolUse.Name, description, confirmationTier.Value, entityContext)
                         };
 
                         bool userAllowed;

--- a/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor
+++ b/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor
@@ -91,6 +91,7 @@
                             @foreach (var confirmation in msg.Confirmations)
                             {
                                 var isElevated = confirmation.Request.Tier == ConfirmationTier.Elevated;
+                                var entity = confirmation.Request.Entity;
                                 <div class="cc-ai-confirmation @(isElevated ? "cc-ai-confirmation--elevated" : "")">
                                     @if (confirmation.Result is null)
                                     {
@@ -102,8 +103,54 @@
                                                     <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
                                                 </svg>
                                             }
-                                            The assistant wants to <strong>@confirmation.Request.Description</strong>
+                                            @if (entity is not null)
+                                            {
+                                                @:The assistant wants to <strong>@FormatOperationVerb(entity.OperationType)</strong> this <strong>@entity.EntityType</strong>:
+                                            }
+                                            else
+                                            {
+                                                @:The assistant wants to <strong>@confirmation.Request.Description</strong>
+                                            }
                                         </p>
+                                        @if (entity is not null)
+                                        {
+                                            <div class="cc-ai-entity-card">
+                                                <div class="cc-ai-entity-header">
+                                                    <span class="cc-ai-entity-name">@entity.DisplayName</span>
+                                                    @if (entity.EntityId is not null)
+                                                    {
+                                                        <span class="cc-ai-entity-id">#@entity.EntityId</span>
+                                                    }
+                                                </div>
+                                                @if (entity.Fields is { Count: > 0 })
+                                                {
+                                                    <div class="cc-ai-field-list">
+                                                        @foreach (var field in entity.Fields)
+                                                        {
+                                                            <div class="cc-ai-field-row">
+                                                                <span class="cc-ai-field-label">@field.FieldLabel</span>
+                                                                <span class="cc-ai-field-values">
+                                                                    @if (entity.OperationType == "create")
+                                                                    {
+                                                                        <span class="cc-ai-field-value--proposed">@(field.ProposedValue ?? "—")</span>
+                                                                    }
+                                                                    else if (entity.OperationType == "update")
+                                                                    {
+                                                                        <span class="cc-ai-field-value--current">@(field.CurrentValue ?? "—")</span>
+                                                                        <span class="cc-ai-field-arrow">&rarr;</span>
+                                                                        <span class="cc-ai-field-value--proposed">@(field.ProposedValue ?? "—")</span>
+                                                                    }
+                                                                    else
+                                                                    {
+                                                                        <span class="cc-ai-field-value--current">@(field.CurrentValue ?? "—")</span>
+                                                                    }
+                                                                </span>
+                                                            </div>
+                                                        }
+                                                    </div>
+                                                }
+                                            </div>
+                                        }
                                         <div class="cc-ai-confirmation-actions">
                                             <button class="cc-ai-btn-allow" @onclick="() => HandleConfirmation(confirmation, true)">Allow</button>
                                             <button class="cc-ai-btn-deny" @onclick="() => HandleConfirmation(confirmation, false)">Deny</button>
@@ -542,6 +589,24 @@
     {
         AiAgent.SetPageContext(e.Location);
     }
+
+    private static string FormatOperationVerb(string operationType) => operationType switch
+    {
+        "create" => "create",
+        "update" => "update",
+        "delete" => "delete",
+        "cancel" => "cancel",
+        "activate" => "activate",
+        "archive" => "archive",
+        "duplicate" => "duplicate",
+        "achieve" => "mark as achieved",
+        "abandon" => "mark as abandoned",
+        "change_role" => "change role of",
+        "deactivate" => "deactivate",
+        "reactivate" => "reactivate",
+        "reset_password" => "reset password for",
+        _ => operationType.Replace('_', ' '),
+    };
 
     private class ConfirmationRecord
     {

--- a/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor.css
+++ b/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor.css
@@ -535,6 +535,80 @@
     font-style: italic;
 }
 
+/* Entity detail card within confirmation */
+.cc-ai-entity-card {
+    margin: var(--space-2) 0;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-bg-alt);
+}
+
+.cc-ai-entity-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-2);
+    padding-bottom: var(--space-1);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.cc-ai-entity-name {
+    font-weight: 600;
+    font-size: var(--text-xs);
+    color: var(--color-text);
+}
+
+.cc-ai-entity-id {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+}
+
+.cc-ai-field-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.cc-ai-field-row {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    font-size: var(--text-xs);
+    line-height: 1.6;
+}
+
+.cc-ai-field-label {
+    flex-shrink: 0;
+    min-width: 80px;
+    color: var(--color-text-muted);
+    font-weight: 500;
+}
+
+.cc-ai-field-values {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-1);
+    min-width: 0;
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
+.cc-ai-field-value--current {
+    color: var(--color-text-muted);
+    text-decoration: line-through;
+}
+
+.cc-ai-field-arrow {
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+}
+
+.cc-ai-field-value--proposed {
+    color: var(--color-text);
+    font-weight: 500;
+}
+
 /* Mobile responsive */
 @media (max-width: 768px) {
     .cc-ai-panel {


### PR DESCRIPTION
## Summary
- Adds `EntityContext` and `FieldChange` data models to enrich tool confirmation requests with structured entity data
- Rewrites `AiToolExecutor.BuildConfirmationDescriptionAsync` to return entity context alongside descriptions, building field-level change details for all entity types (Client, Appointment, Meal Plan, Goal, Progress Entry, User)
- Renders inline entity detail cards in the AI assistant panel showing current → proposed values for updates, proposed values for creates, and identifying fields for deletes

## Test plan
- [ ] `dotnet build` succeeds with zero errors/warnings
- [ ] AI assistant: "Update client X's first name to Y" → confirmation shows current vs proposed name
- [ ] AI assistant: "Create an appointment for client X" → confirmation shows proposed appointment details
- [ ] AI assistant: "Delete client X" → confirmation shows client details being deleted
- [ ] Elevated-tier confirmations (user management) render enriched cards with warning styling
- [ ] Resolved confirmations still show compact text fallback
- [ ] Plain description fallback works when entity context is null

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)