### PR TITLE
Redesign client detail page with clinical chart widgets

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Clients/ClientDetail.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientDetail.razor
@@ -8,12 +8,10 @@
 @using Nutrir.Core.DTOs
 @using Nutrir.Core.Enums
 @using Nutrir.Core.Interfaces
+@using Nutrir.Web.Components.Widgets
 @using Nutrir.Web.Services
 @attribute [Authorize(Roles = "Admin,Nutritionist,Assistant")]
 @inject IClientService ClientService
-@inject IAppointmentService AppointmentService
-@inject IMealPlanService MealPlanService
-@inject IProgressService ProgressService
 @inject IConsentFormService ConsentFormService
 @inject IAuditLogService AuditLogService
 @inject AuthenticationStateProvider AuthenticationStateProvider
@@ -179,8 +177,24 @@
             </div>
         }
 
+        @* ── Widget Grid: Progress + Meal Plan ─────────── *@
+        <div class="widget-grid section-animate" style="animation-delay: 160ms;">
+            <ProgressSummaryWidget ClientId="@Id" @key="@($"progress-{_refreshKey}")" />
+            <ActiveMealPlanCard ClientId="@Id" @key="@($"mealplan-{_refreshKey}")" />
+        </div>
+
+        @* ── Upcoming Appointments Widget ──────────────── *@
+        <div class="section-animate" style="animation-delay: 240ms;">
+            <UpcomingAppointmentsWidget ClientId="@Id" @key="@($"appointments-{_refreshKey}")" />
+        </div>
+
+        @* ── Visit History Timeline ────────────────────── *@
+        <div class="section-animate" style="animation-delay: 320ms;">
+            <VisitHistoryTimeline ClientId="@Id" @key="@($"timeline-{_refreshKey}")" />
+        </div>
+
         @* ── Consent Form ──────────────────────────────────── *@
-        <div class="table-card section-animate" style="animation-delay: 160ms;">
+        <div class="table-card section-animate" style="animation-delay: 400ms;">
             <div class="section-header">
                 <span class="section-header-label">Consent Form</span>
             </div>
@@ -248,134 +262,8 @@
             </div>
         </div>
 
-        @* ── Upcoming Appointments ───────────────────────── *@
-        <div class="table-card section-animate" style="animation-delay: 240ms;">
-            <div class="section-header">
-                <span class="section-header-label">
-                    Upcoming Appointments
-                    @if (_upcomingAppointments.Count > 0)
-                    {
-                        <span class="section-count">(@_upcomingAppointments.Count)</span>
-                    }
-                </span>
-                <a href="/appointments/new?clientId=@Id" class="section-header-action">Schedule</a>
-            </div>
-            @if (_upcomingAppointments.Count == 0)
-            {
-                <div class="section-empty">
-                    <p>No upcoming appointments</p>
-                </div>
-            }
-            else
-            {
-                <div class="section-list">
-                    @foreach (var appt in _upcomingAppointments)
-                    {
-                        <a href="/appointments/@appt.Id" class="list-row">
-                            <div class="list-row-primary">
-                                <span class="list-row-title">@FormatApptType(appt.Type)</span>
-                                <span class="list-row-meta">
-                                    @TimeZoneService.ToUserLocal(appt.StartTime).ToString("MMM d, yyyy") · @appt.DurationMinutes min
-                                    <span> · @appt.Location</span>
-                                </span>
-                            </div>
-                            <Badge Variant="@GetApptStatusVariant(appt.Status)">@appt.Status</Badge>
-                        </a>
-                    }
-                </div>
-            }
-        </div>
-
-        @* ── Meal Plans ──────────────────────────────────── *@
-        <div class="table-card section-animate" style="animation-delay: 320ms;">
-            <div class="section-header">
-                <span class="section-header-label">
-                    Meal Plans
-                    @if (_clientMealPlans.Count > 0)
-                    {
-                        <span class="section-count">(@_clientMealPlans.Count)</span>
-                    }
-                </span>
-                <a href="/meal-plans/new?clientId=@Id" class="section-header-action">Create</a>
-            </div>
-            @if (_clientMealPlans.Count == 0)
-            {
-                <div class="section-empty">
-                    <p>No meal plans</p>
-                </div>
-            }
-            else
-            {
-                <div class="section-list">
-                    @foreach (var plan in _clientMealPlans)
-                    {
-                        <a href="/meal-plans/@plan.Id" class="list-row">
-                            <div class="list-row-primary">
-                                <span class="list-row-title">@plan.Title</span>
-                                <span class="list-row-meta">
-                                    @if (plan.StartDate.HasValue)
-                                    {
-                                        @plan.StartDate.Value.ToString("MMM d")
-                                        <span> — </span>
-                                        @(plan.EndDate?.ToString("MMM d") ?? "")
-                                    }
-                                </span>
-                            </div>
-                            <Badge Variant="@GetPlanStatusVariant(plan.Status)">@plan.Status</Badge>
-                        </a>
-                    }
-                    <a href="/meal-plans?clientId=@Id" class="list-row list-row-viewall">
-                        View All
-                    </a>
-                </div>
-            }
-        </div>
-
-        @* ── Progress ───────────────────────────────────────── *@
-        <div class="table-card section-animate" style="animation-delay: 400ms;">
-            <div class="section-header">
-                <span class="section-header-label">
-                    Progress
-                    @if (_recentProgress.Count > 0)
-                    {
-                        <span class="section-count">(@_recentProgress.Count)</span>
-                    }
-                </span>
-                <a href="/clients/@Id/progress/create" class="section-header-action">New Entry</a>
-            </div>
-            @if (_recentProgress.Count == 0)
-            {
-                <div class="section-empty">
-                    <p>No progress entries</p>
-                </div>
-            }
-            else
-            {
-                <div class="section-list">
-                    @foreach (var entry in _recentProgress)
-                    {
-                        <a href="/progress/@entry.Id" class="list-row">
-                            <div class="list-row-primary">
-                                <span class="list-row-title">@entry.EntryDate.ToString("MMM d, yyyy")</span>
-                                <span class="list-row-meta">
-                                    @entry.MeasurementCount measurement@(entry.MeasurementCount != 1 ? "s" : "")
-                                    @if (!string.IsNullOrEmpty(entry.NotePreview))
-                                    {
-                                        <span> · @entry.NotePreview</span>
-                                    }
-                                </span>
-                            </div>
-                        </a>
-                    }
-                    <a href="/clients/@Id/progress" class="list-row list-row-viewall">
-                        View All
-                    </a>
-                </div>
-            }
-        </div>
-
         @* ── Metadata Footer ─────────────────────────────── *@
-        <div class="meta-footer section-animate" style="animation-delay: 480ms;">
+        <div class="meta-footer section-animate" style="animation-delay: 480ms;" @key="_refreshKey">
             <span>Created: @_client.CreatedAt.ToString("MMM d, yyyy")</span>
             @if (_client.UpdatedAt.HasValue)
             {
@@ -391,10 +279,8 @@
     [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
 
     private ClientDto? _client;
-    private List<AppointmentDto> _upcomingAppointments = [];
-    private List<MealPlanSummaryDto> _clientMealPlans = [];
-    private List<ProgressEntrySummaryDto> _recentProgress = [];
     private ConsentFormDto? _latestConsentForm;
+    private int _refreshKey;
     private bool _isLoading = true;
     private bool _showDeleteConfirm;
     private bool _isDeleting;
@@ -409,9 +295,6 @@
         await NotificationService.StartAsync();
         await TimeZoneService.InitializeAsync();
         _client = await ClientService.GetByIdAsync(Id);
-        _upcomingAppointments = await AppointmentService.GetUpcomingByClientAsync(Id, 5);
-        _clientMealPlans = await MealPlanService.GetByClientAsync(Id, 3);
-        _recentProgress = await ProgressService.GetRecentByClientAsync(Id, 3);
         _latestConsentForm = await ConsentFormService.GetLatestFormAsync(Id);
         _isLoading = false;
 
@@ -426,7 +309,7 @@
     private void OnEntityChanged(EntityChangeNotification notification)
     {
         var isThisClient = notification.EntityType == "Client" && notification.EntityId == Id;
-        var isRelatedEntity = notification.EntityType is "MealPlan" or "Appointment";
+        var isRelatedEntity = notification.EntityType is "MealPlan" or "Appointment" or "ProgressEntry";
 
         if (!isThisClient && !isRelatedEntity)
             return;
@@ -434,10 +317,8 @@
         _ = InvokeAsync(async () =>
         {
             _client = await ClientService.GetByIdAsync(Id);
-            _upcomingAppointments = await AppointmentService.GetUpcomingByClientAsync(Id, 5);
-            _clientMealPlans = await MealPlanService.GetByClientAsync(Id, 3);
-            _recentProgress = await ProgressService.GetRecentByClientAsync(Id, 3);
             _latestConsentForm = await ConsentFormService.GetLatestFormAsync(Id);
+            _refreshKey++;
             _refreshedByRealTime = true;
             StateHasChanged();
         });
@@ -455,30 +336,6 @@
         var last = client.LastName.Length > 0 ? client.LastName[0] : '?';
         return $"{char.ToUpper(first)}{char.ToUpper(last)}";
     }
-
-    private static BadgeVariant GetPlanStatusVariant(MealPlanStatus status) => status switch
-    {
-        MealPlanStatus.Draft => BadgeVariant.Secondary,
-        MealPlanStatus.Active => BadgeVariant.Success,
-        MealPlanStatus.Archived => BadgeVariant.Accent,
-        _ => BadgeVariant.Primary
-    };
-
-    private static BadgeVariant GetApptStatusVariant(AppointmentStatus status) => status switch
-    {
-        AppointmentStatus.Scheduled => BadgeVariant.Primary,
-        AppointmentStatus.Completed => BadgeVariant.Success,
-        AppointmentStatus.Cancelled => BadgeVariant.Secondary,
-        _ => BadgeVariant.Primary
-    };
-
-    private static string FormatApptType(AppointmentType type) => type switch
-    {
-        AppointmentType.InitialConsultation => "Initial Consultation",
-        AppointmentType.FollowUp => "Follow-Up",
-        AppointmentType.CheckIn => "Check-In",
-        _ => type.ToString()
-    };
 
     private void NavigateToEdit()
     {

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientDetail.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientDetail.razor.css
@@ -414,6 +414,13 @@
     50% { opacity: 0.4; transform: scale(0.75); }
 }
 
+/* ── Widget Grid ─────────────────────────────────────── */
+.widget-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-4);
+}
+
 /* ── Responsive: Tablet ──────────────────────────────── */
 @media (max-width: 768px) {
     .hero {
@@ -422,6 +429,10 @@
 
     .hero-actions {
         padding-left: calc(64px + var(--space-4));
+    }
+
+    .widget-grid {
+        grid-template-columns: 1fr;
     }
 }
 

--- a/src/Nutrir.Web/Components/Widgets/ActiveMealPlanCard.razor
+++ b/src/Nutrir.Web/Components/Widgets/ActiveMealPlanCard.razor
@@ -1,0 +1,107 @@
+@using Nutrir.Core.DTOs
+@using Nutrir.Core.Enums
+@using Nutrir.Core.Interfaces
+@using Nutrir.Web.Services
+
+@inject IMealPlanService MealPlanService
+@inject ITimeZoneService TimeZoneService
+
+<Panel Title="Active Meal Plan">
+    <HeaderExtra>
+        <a href="/meal-plans?clientId=@ClientId" class="section-header-action">View All</a>
+    </HeaderExtra>
+    <ChildContent>
+        @if (_loading)
+        {
+            <div class="meal-plan-loading">Loading...</div>
+        }
+        else if (_activePlan is not null)
+        {
+            <div class="meal-plan-body">
+                <div class="meal-plan-title-row">
+                    <span class="meal-plan-title">@_activePlan.Title</span>
+                    <Badge Variant="@GetBadgeVariant(_activePlan.Status)">@_activePlan.Status</Badge>
+                </div>
+
+                @if (_activePlan.StartDate.HasValue || _activePlan.EndDate.HasValue)
+                {
+                    <div class="meal-plan-dates">
+                        @FormatDate(_activePlan.StartDate) &mdash; @FormatDate(_activePlan.EndDate)
+                    </div>
+                }
+
+                @if (_activePlan.CalorieTarget.HasValue)
+                {
+                    <div class="meal-plan-calories">
+                        <span class="calorie-value">@_activePlan.CalorieTarget.Value.ToString("N0")</span>
+                        <span class="calorie-label">kcal / day</span>
+                    </div>
+                }
+
+                @if (_activePlan.ProteinTargetG.HasValue || _activePlan.CarbsTargetG.HasValue || _activePlan.FatTargetG.HasValue)
+                {
+                    <div class="macro-row">
+                        <div class="macro-item">
+                            <span class="macro-value">@FormatMacro(_activePlan.ProteinTargetG)</span>
+                            <span class="macro-label">Protein</span>
+                        </div>
+                        <div class="macro-item">
+                            <span class="macro-value">@FormatMacro(_activePlan.CarbsTargetG)</span>
+                            <span class="macro-label">Carbs</span>
+                        </div>
+                        <div class="macro-item">
+                            <span class="macro-value">@FormatMacro(_activePlan.FatTargetG)</span>
+                            <span class="macro-label">Fat</span>
+                        </div>
+                    </div>
+                }
+
+                <div class="meal-plan-stats">
+                    <span>@_activePlan.DayCount days</span>
+                    <span class="stats-separator">&middot;</span>
+                    <span>@_activePlan.TotalItems items</span>
+                </div>
+
+                <a href="/meal-plans/@_activePlan.Id" class="view-plan-link">View Plan</a>
+            </div>
+        }
+        else
+        {
+            <div class="empty-state">
+                <p class="empty-state-text">No active meal plan</p>
+                <a href="/meal-plans/new?clientId=@ClientId">
+                    <Button Variant="ButtonVariant.Outline">Create Meal Plan</Button>
+                </a>
+            </div>
+        }
+    </ChildContent>
+</Panel>
+
+@code {
+    [Parameter] public int ClientId { get; set; }
+
+    private MealPlanSummaryDto? _activePlan;
+    private bool _loading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await TimeZoneService.InitializeAsync();
+        var plans = await MealPlanService.GetByClientAsync(ClientId, 3);
+        _activePlan = plans.FirstOrDefault(p => p.Status == MealPlanStatus.Active) ?? plans.FirstOrDefault();
+        _loading = false;
+    }
+
+    private static BadgeVariant GetBadgeVariant(MealPlanStatus status) => status switch
+    {
+        MealPlanStatus.Active => BadgeVariant.Success,
+        MealPlanStatus.Draft => BadgeVariant.Secondary,
+        MealPlanStatus.Archived => BadgeVariant.Accent,
+        _ => BadgeVariant.Secondary
+    };
+
+    private static string FormatDate(DateOnly? date) =>
+        date?.ToString("MMM d, yyyy", System.Globalization.CultureInfo.CurrentCulture) ?? "—";
+
+    private static string FormatMacro(decimal? value) =>
+        value.HasValue ? $"{value.Value:N0}g" : "—";
+}

--- a/src/Nutrir.Web/Components/Widgets/ActiveMealPlanCard.razor.css
+++ b/src/Nutrir.Web/Components/Widgets/ActiveMealPlanCard.razor.css
@@ -1,0 +1,122 @@
+/* ── Loading ─────────────────────────────────────────── */
+.meal-plan-loading {
+    padding: var(--space-8);
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
+}
+
+/* ── Plan Body ──────────────────────────────────────── */
+.meal-plan-body {
+    padding: var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+
+/* ── Title Row ──────────────────────────────────────── */
+.meal-plan-title-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+}
+
+.meal-plan-title {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+/* ── Date Range ─────────────────────────────────────── */
+.meal-plan-dates {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+}
+
+/* ── Calorie Target ─────────────────────────────────── */
+.meal-plan-calories {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-1);
+}
+
+.calorie-value {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    font-weight: 700;
+    color: var(--color-text);
+    line-height: var(--leading-tight);
+}
+
+.calorie-label {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+}
+
+/* ── Macro Summary Row ──────────────────────────────── */
+.macro-row {
+    display: flex;
+    gap: var(--space-4);
+}
+
+.macro-item {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+}
+
+.macro-value {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.macro-label {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+}
+
+/* ── Plan Stats ─────────────────────────────────────── */
+.meal-plan-stats {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.stats-separator {
+    color: var(--color-text-muted);
+}
+
+/* ── View Plan Link ─────────────────────────────────── */
+.view-plan-link {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-primary);
+    text-decoration: none;
+    transition: opacity var(--duration-fast) var(--ease-default);
+}
+
+.view-plan-link:hover {
+    opacity: 0.8;
+}
+
+/* ── Empty State ────────────────────────────────────── */
+.empty-state {
+    padding: var(--space-8) var(--space-4);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-3);
+}
+
+.empty-state-text {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    margin: 0;
+}

--- a/src/Nutrir.Web/Components/Widgets/ProgressSummaryWidget.razor
+++ b/src/Nutrir.Web/Components/Widgets/ProgressSummaryWidget.razor
@@ -1,0 +1,122 @@
+@using Nutrir.Core.DTOs
+@using Nutrir.Core.Enums
+@using Nutrir.Core.Interfaces
+@using Nutrir.Web.Services
+
+@inject IProgressService ProgressService
+@inject ITimeZoneService TimeZoneService
+
+<div class="section-animate">
+    <Panel Title="Progress Summary">
+        <HeaderExtra>
+            <a href="/clients/@ClientId/progress" class="panel-link">View All</a>
+        </HeaderExtra>
+        <ChildContent>
+            @if (_loading)
+            {
+                <p>Loading...</p>
+            }
+            else if (!_hasData)
+            {
+                <div class="empty-state">
+                    <p class="empty-state-title">No progress data recorded yet</p>
+                    <a href="/clients/@ClientId/progress">Record first entry</a>
+                </div>
+            }
+            else
+            {
+                @if (_chartData?.Points.Count > 0)
+                {
+                    <div class="metrics-row">
+                        <MetricCard Label="@_chartData.Label"
+                                    Value="@FormatValue(_latestValue, _chartData.Unit)"
+                                    DeltaText="@_deltaText"
+                                    Delta="@_delta" />
+                    </div>
+                }
+
+                @if (_activeGoals.Count > 0)
+                {
+                    <div class="goals-section">
+                        <h4 class="goals-heading">Active Goals</h4>
+                        <ul class="goals-list">
+                            @foreach (var goal in _activeGoals)
+                            {
+                                <li class="goal-item">
+                                    <div class="goal-header">
+                                        <Badge Variant="BadgeVariant.Primary">@goal.GoalType.ToString()</Badge>
+                                        <span class="goal-title">@goal.Title</span>
+                                    </div>
+                                    @if (goal.TargetValue.HasValue)
+                                    {
+                                        <span class="goal-target">
+                                            Target: @goal.TargetValue.Value.ToString("N1") @goal.TargetUnit
+                                        </span>
+                                    }
+                                    @if (goal.TargetDate.HasValue)
+                                    {
+                                        <span class="goal-date">
+                                            By @goal.TargetDate.Value.ToString("MMM d, yyyy")
+                                        </span>
+                                    }
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                }
+            }
+        </ChildContent>
+    </Panel>
+</div>
+
+@code {
+    [Parameter] public int ClientId { get; set; }
+
+    private bool _loading = true;
+    private bool _hasData;
+    private List<ProgressGoalSummaryDto> _activeGoals = new();
+    private ProgressChartDataDto? _chartData;
+    private decimal _latestValue;
+    private string? _deltaText;
+    private MetricDelta _delta = MetricDelta.Flat;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await TimeZoneService.InitializeAsync();
+
+        var entriesTask = ProgressService.GetRecentByClientAsync(ClientId, 3);
+        var goalsTask = ProgressService.GetGoalsByClientAsync(ClientId);
+        var chartTask = ProgressService.GetChartDataAsync(ClientId, MetricType.Weight);
+
+        await Task.WhenAll(entriesTask, goalsTask, chartTask);
+
+        var entries = entriesTask.Result;
+        var goals = goalsTask.Result;
+        _chartData = chartTask.Result;
+
+        _activeGoals = goals.Where(g => g.Status == GoalStatus.Active).ToList();
+
+        if (_chartData?.Points.Count > 0)
+        {
+            var points = _chartData.Points.OrderBy(p => p.Date).ToList();
+            _latestValue = points[^1].Value;
+
+            if (points.Count >= 2)
+            {
+                var previous = points[^2].Value;
+                var diff = _latestValue - previous;
+                _deltaText = diff >= 0 ? $"+{diff:N1}" : $"{diff:N1}";
+                _delta = diff > 0 ? MetricDelta.Up : diff < 0 ? MetricDelta.Down : MetricDelta.Flat;
+            }
+        }
+
+        _hasData = entries.Count > 0 || _activeGoals.Count > 0;
+        _loading = false;
+    }
+
+    private static string FormatValue(decimal value, string? unit)
+    {
+        var formatted = value.ToString("N1");
+        return string.IsNullOrEmpty(unit) ? formatted : $"{formatted} {unit}";
+    }
+}

--- a/src/Nutrir.Web/Components/Widgets/ProgressSummaryWidget.razor.css
+++ b/src/Nutrir.Web/Components/Widgets/ProgressSummaryWidget.razor.css
@@ -1,0 +1,86 @@
+.metrics-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    margin-bottom: var(--space-4);
+}
+
+.goals-section {
+    margin-top: var(--space-4);
+}
+
+.goals-heading {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin: 0 0 var(--space-2) 0;
+}
+
+.goals-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.goal-item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+}
+
+.goal-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.goal-title {
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--color-text-primary);
+}
+
+.goal-target,
+.goal-date {
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+}
+
+.panel-link {
+    font-size: var(--text-sm);
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+.panel-link:hover {
+    text-decoration: underline;
+}
+
+.empty-state {
+    text-align: center;
+    padding: var(--space-6) var(--space-4);
+}
+
+.empty-state-title {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    margin: 0 0 var(--space-2) 0;
+}
+
+.empty-state a {
+    font-size: var(--text-sm);
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+.empty-state a:hover {
+    text-decoration: underline;
+}

--- a/src/Nutrir.Web/Components/Widgets/UpcomingAppointmentsWidget.razor
+++ b/src/Nutrir.Web/Components/Widgets/UpcomingAppointmentsWidget.razor
@@ -1,0 +1,168 @@
+@using Microsoft.AspNetCore.Components.Authorization
+@using System.Security.Claims
+@using Nutrir.Core.DTOs
+@using Nutrir.Core.Enums
+@using Nutrir.Core.Interfaces
+@using Nutrir.Web.Services
+
+@inject IAppointmentService AppointmentService
+@inject ITimeZoneService TimeZoneService
+@inject NavigationManager NavigationManager
+@inject AuthenticationStateProvider AuthenticationStateProvider
+
+<Panel Title="Upcoming Appointments" Count="@_appointments?.Count" >
+    <HeaderExtra>
+        <a class="panel-header-link" href="/appointments/new?clientId=@ClientId">Schedule</a>
+    </HeaderExtra>
+    <ChildContent>
+        @if (_appointments is null)
+        {
+            <p class="widget-loading">Loading appointments...</p>
+        }
+        else if (_appointments.Count == 0)
+        {
+            <div class="empty-state">
+                <p class="empty-state-text">No upcoming appointments</p>
+                <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small"
+                        OnClick="@(() => NavigationManager.NavigateTo($"/appointments/new?clientId={ClientId}"))">
+                    Schedule Appointment
+                </Button>
+            </div>
+        }
+        else
+        {
+            <div class="appointment-list">
+                @foreach (var appt in _appointments)
+                {
+                    var localStart = TimeZoneService.ToUserLocal(appt.StartTime);
+                    var daysUntil = (localStart.Date - TimeZoneService.UserNow.Date).Days;
+                    var countdown = daysUntil switch
+                    {
+                        0 => "Today",
+                        1 => "Tomorrow",
+                        _ => $"in {daysUntil} days"
+                    };
+
+                    <div class="appointment-card">
+                        <div class="appointment-main">
+                            <div class="appointment-datetime">
+                                <span class="appointment-date">@localStart.ToString("ddd, MMM d")</span>
+                                <span class="appointment-time-sep">&middot;</span>
+                                <span class="appointment-time">@localStart.ToString("h:mm tt")</span>
+                                <span class="appointment-countdown">@countdown</span>
+                            </div>
+                            <div class="appointment-badges">
+                                <Badge Variant="@GetTypeBadgeVariant(appt.Type)">@FormatAppointmentType(appt.Type)</Badge>
+                                <Badge Variant="@GetStatusBadgeVariant(appt.Status)">@appt.Status</Badge>
+                            </div>
+                            <div class="appointment-details">
+                                <span class="appointment-location">
+                                    @switch (appt.Location)
+                                    {
+                                        case AppointmentLocation.InPerson:
+                                            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+                                            <span>In Person</span>
+                                            break;
+                                        case AppointmentLocation.Virtual:
+                                            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+                                            <span>Virtual</span>
+                                            break;
+                                        case AppointmentLocation.Phone:
+                                            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"/></svg>
+                                            <span>Phone</span>
+                                            break;
+                                    }
+                                </span>
+                                <span class="appointment-duration">@appt.DurationMinutes min</span>
+                            </div>
+                        </div>
+                        <div class="appointment-actions">
+                            @if (_cancellingId == appt.Id)
+                            {
+                                <span class="cancel-confirm-text">Cancel this appointment?</span>
+                                <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small"
+                                        OnClick="@(() => ConfirmCancelAsync(appt.Id))"
+                                        Disabled="_isCancelling">
+                                    Yes
+                                </Button>
+                                <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small"
+                                        OnClick="@(() => _cancellingId = null)">
+                                    No
+                                </Button>
+                            }
+                            else
+                            {
+                                <a class="action-link" href="/appointments/@appt.Id/edit">Reschedule</a>
+                                <button class="action-btn action-btn-cancel" @onclick="@(() => _cancellingId = appt.Id)">Cancel</button>
+                            }
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+    </ChildContent>
+</Panel>
+
+@code {
+    [Parameter] public int ClientId { get; set; }
+
+    private List<AppointmentDto>? _appointments;
+    private int? _cancellingId;
+    private bool _isCancelling;
+    private string? _userId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await TimeZoneService.InitializeAsync();
+
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        _userId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        _appointments = await AppointmentService.GetUpcomingByClientAsync(ClientId, 3);
+    }
+
+    private async Task ConfirmCancelAsync(int appointmentId)
+    {
+        if (_userId is null) return;
+
+        _isCancelling = true;
+
+        try
+        {
+            await AppointmentService.UpdateStatusAsync(appointmentId, AppointmentStatus.Cancelled, _userId);
+            _appointments = await AppointmentService.GetUpcomingByClientAsync(ClientId, 3);
+        }
+        finally
+        {
+            _cancellingId = null;
+            _isCancelling = false;
+        }
+    }
+
+    private static string FormatAppointmentType(AppointmentType type) => type switch
+    {
+        AppointmentType.InitialConsultation => "Initial Consultation",
+        AppointmentType.FollowUp => "Follow-Up",
+        AppointmentType.CheckIn => "Check-In",
+        _ => type.ToString()
+    };
+
+    private static BadgeVariant GetTypeBadgeVariant(AppointmentType type) => type switch
+    {
+        AppointmentType.InitialConsultation => BadgeVariant.Accent,
+        AppointmentType.FollowUp => BadgeVariant.Secondary,
+        AppointmentType.CheckIn => BadgeVariant.Primary,
+        _ => BadgeVariant.Primary
+    };
+
+    private static BadgeVariant GetStatusBadgeVariant(AppointmentStatus status) => status switch
+    {
+        AppointmentStatus.Scheduled => BadgeVariant.Primary,
+        AppointmentStatus.Confirmed => BadgeVariant.Success,
+        AppointmentStatus.Completed => BadgeVariant.Secondary,
+        AppointmentStatus.NoShow => BadgeVariant.Warning,
+        AppointmentStatus.LateCancellation => BadgeVariant.Warning,
+        AppointmentStatus.Cancelled => BadgeVariant.Error,
+        _ => BadgeVariant.Primary
+    };
+}

--- a/src/Nutrir.Web/Components/Widgets/UpcomingAppointmentsWidget.razor.css
+++ b/src/Nutrir.Web/Components/Widgets/UpcomingAppointmentsWidget.razor.css
@@ -1,0 +1,189 @@
+.widget-loading {
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+    padding: var(--space-4);
+    text-align: center;
+}
+
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-6) var(--space-4);
+}
+
+.empty-state-text {
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+    margin: 0;
+}
+
+.appointment-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+
+.appointment-card {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    transition: box-shadow 0.15s ease;
+}
+
+.appointment-card:hover {
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.appointment-main {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    min-width: 0;
+    flex: 1;
+}
+
+.appointment-datetime {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    flex-wrap: wrap;
+}
+
+.appointment-date {
+    font-weight: 600;
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+}
+
+.appointment-time-sep {
+    color: var(--text-tertiary);
+}
+
+.appointment-time {
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+}
+
+.appointment-countdown {
+    font-size: var(--text-xs);
+    color: var(--color-primary);
+    font-weight: 500;
+    margin-left: var(--space-2);
+}
+
+.appointment-badges {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+}
+
+.appointment-details {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+}
+
+.appointment-location {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.appointment-location .icon {
+    flex-shrink: 0;
+}
+
+.appointment-duration {
+    white-space: nowrap;
+}
+
+.appointment-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+}
+
+.action-link {
+    font-size: var(--text-xs);
+    color: var(--color-primary);
+    text-decoration: none;
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-sm);
+    transition: background 0.15s ease;
+}
+
+.action-link:hover {
+    background: var(--color-primary-subtle);
+    text-decoration: none;
+}
+
+.action-btn {
+    font-size: var(--text-xs);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-sm);
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.action-btn-cancel {
+    color: var(--text-secondary);
+}
+
+.action-btn-cancel:hover {
+    color: var(--color-error);
+    background: var(--color-error-subtle, rgba(239, 68, 68, 0.08));
+}
+
+.cancel-confirm-text {
+    font-size: var(--text-xs);
+    color: var(--color-error);
+    white-space: nowrap;
+}
+
+.panel-header-link {
+    font-size: var(--text-sm);
+    color: var(--color-primary);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.panel-header-link:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+    .appointment-card {
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+
+    .appointment-actions {
+        align-self: flex-start;
+    }
+
+    .appointment-datetime {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0;
+    }
+
+    .appointment-time-sep {
+        display: none;
+    }
+
+    .appointment-countdown {
+        margin-left: 0;
+    }
+}

--- a/src/Nutrir.Web/Components/Widgets/VisitHistoryTimeline.razor
+++ b/src/Nutrir.Web/Components/Widgets/VisitHistoryTimeline.razor
@@ -1,0 +1,165 @@
+@using Nutrir.Core.DTOs
+@using Nutrir.Core.Enums
+@using Nutrir.Core.Interfaces
+@using Nutrir.Web.Services
+
+@inject IAppointmentService AppointmentService
+@inject IMealPlanService MealPlanService
+@inject IProgressService ProgressService
+@inject ITimeZoneService TimeZoneService
+
+<Panel Title="Visit History" Count="@_entries?.Count">
+    @if (_loading)
+    {
+        <div class="timeline-loading">Loading visit history...</div>
+    }
+    else if (_entries is null || _entries.Count == 0)
+    {
+        <div class="timeline-empty">No visit history yet.</div>
+    }
+    else
+    {
+        <div class="timeline">
+            @foreach (var entry in _entries.Take(_displayCount))
+            {
+                <ActivityItem DotClass="@GetDotClass(entry.Type)" TimeAgo="@GetTimeAgo(entry.Date)">
+                    <div class="timeline-entry">
+                        <div class="timeline-title-row">
+                            <span class="timeline-icon">@((MarkupString)entry.Icon)</span>
+                            <a href="@entry.Link" class="timeline-title">@entry.Title</a>
+                        </div>
+                        <div class="timeline-description">@entry.Description</div>
+                    </div>
+                </ActivityItem>
+            }
+        </div>
+
+        @if (_displayCount < _entries.Count)
+        {
+            <div class="timeline-load-more">
+                <button class="btn-load-more" @onclick="LoadMore">
+                    Load more (@(_entries.Count - _displayCount) remaining)
+                </button>
+            </div>
+        }
+    }
+</Panel>
+
+@code {
+    [Parameter] public int ClientId { get; set; }
+
+    private record TimelineEntry(DateTime Date, string Type, string Icon, string Title, string Description, string? Link);
+
+    private List<TimelineEntry>? _entries;
+    private bool _loading = true;
+    private int _pageSize = 10;
+    private int _displayCount = 10;
+
+    private static readonly string IconCalendar = @"<svg width=""16"" height=""16"" viewBox=""0 0 16 16"" fill=""none"" stroke=""currentColor"" stroke-width=""1.5"" stroke-linecap=""round"" stroke-linejoin=""round""><rect x=""2"" y=""3"" width=""12"" height=""11"" rx=""1.5""/><path d=""M2 6.5h12M5.5 1.5v3M10.5 1.5v3""/></svg>";
+    private static readonly string IconUtensils = @"<svg width=""16"" height=""16"" viewBox=""0 0 16 16"" fill=""none"" stroke=""currentColor"" stroke-width=""1.5"" stroke-linecap=""round"" stroke-linejoin=""round""><path d=""M5 1v5.5a2.5 2.5 0 0 1-5 0V1M2.5 1v14M11 1c0 3.5 3 3.5 3 6 0 1.5-1 2.5-2.5 2.5S9 8.5 9 7c0-2.5 3-2.5 3-6M12.5 9.5v5.5""/></svg>";
+    private static readonly string IconChart = @"<svg width=""16"" height=""16"" viewBox=""0 0 16 16"" fill=""none"" stroke=""currentColor"" stroke-width=""1.5"" stroke-linecap=""round"" stroke-linejoin=""round""><path d=""M2 13l4-5 3 3 5-7""/></svg>";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await TimeZoneService.InitializeAsync();
+
+        var appointments = await AppointmentService.GetListAsync(clientId: ClientId);
+        var mealPlans = await MealPlanService.GetByClientAsync(ClientId, 100);
+        var progressEntries = await ProgressService.GetEntriesByClientAsync(ClientId);
+
+        var entries = new List<TimelineEntry>();
+
+        foreach (var appt in appointments)
+        {
+            var localTime = TimeZoneService.ToUserLocal(appt.StartTime);
+            entries.Add(new TimelineEntry(
+                localTime,
+                "appointment",
+                IconCalendar,
+                FormatApptType(appt.Type),
+                $"{appt.Status} \u00b7 {localTime.ToString("MMM d, yyyy")} \u00b7 {appt.DurationMinutes} min",
+                $"/appointments/{appt.Id}"
+            ));
+        }
+
+        foreach (var plan in mealPlans)
+        {
+            var localTime = TimeZoneService.ToUserLocal(plan.CreatedAt);
+            var dateRange = FormatDateRange(plan.StartDate, plan.EndDate);
+            entries.Add(new TimelineEntry(
+                localTime,
+                "mealplan",
+                IconUtensils,
+                plan.Title,
+                $"{plan.Status} \u00b7 {dateRange}",
+                $"/meal-plans/{plan.Id}"
+            ));
+        }
+
+        foreach (var entry in progressEntries)
+        {
+            var localTime = TimeZoneService.ToUserLocal(entry.CreatedAt);
+            var description = $"{entry.MeasurementCount} measurement{(entry.MeasurementCount != 1 ? "s" : "")}";
+            if (!string.IsNullOrWhiteSpace(entry.NotePreview))
+            {
+                description += $" \u00b7 {entry.NotePreview}";
+            }
+            entries.Add(new TimelineEntry(
+                localTime,
+                "progress",
+                IconChart,
+                entry.EntryDate.ToString("MMMM d, yyyy"),
+                description,
+                $"/progress/{entry.Id}"
+            ));
+        }
+
+        _entries = entries.OrderByDescending(e => e.Date).ToList();
+        _loading = false;
+    }
+
+    private void LoadMore()
+    {
+        _displayCount += _pageSize;
+    }
+
+    private static string FormatApptType(AppointmentType type) => type switch
+    {
+        AppointmentType.InitialConsultation => "Initial Consultation",
+        AppointmentType.FollowUp => "Follow-Up",
+        AppointmentType.CheckIn => "Check-In",
+        _ => type.ToString()
+    };
+
+    private static string FormatDateRange(DateOnly? start, DateOnly? end)
+    {
+        if (start.HasValue && end.HasValue)
+            return $"{start.Value.ToString("MMM d")} \u2014 {end.Value.ToString("MMM d")}";
+        if (start.HasValue)
+            return $"From {start.Value.ToString("MMM d")}";
+        if (end.HasValue)
+            return $"Until {end.Value.ToString("MMM d")}";
+        return "No dates set";
+    }
+
+    private static string GetDotClass(string type) => type switch
+    {
+        "appointment" => "dot-appt",
+        "mealplan" => "dot-plan",
+        "progress" => "dot-client",
+        _ => "dot-client"
+    };
+
+    private string GetTimeAgo(DateTime date)
+    {
+        var now = TimeZoneService.UserNow;
+        var diff = now - date;
+
+        if (diff.TotalMinutes < 1) return "just now";
+        if (diff.TotalMinutes < 60) return $"{(int)diff.TotalMinutes} min ago";
+        if (diff.TotalHours < 24) return $"{(int)diff.TotalHours} hours ago";
+        if (diff.TotalDays < 7) return $"{(int)diff.TotalDays} days ago";
+        if (diff.TotalDays < 30) return $"{(int)(diff.TotalDays / 7)} weeks ago";
+        return date.ToString("MMM d, yyyy");
+    }
+}

--- a/src/Nutrir.Web/Components/Widgets/VisitHistoryTimeline.razor.css
+++ b/src/Nutrir.Web/Components/Widgets/VisitHistoryTimeline.razor.css
@@ -1,0 +1,66 @@
+.timeline-loading,
+.timeline-empty {
+    padding: var(--space-6) var(--space-4);
+    text-align: center;
+    color: var(--text-muted);
+    font-size: var(--text-sm);
+}
+
+.timeline-entry {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.timeline-title-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.timeline-icon {
+    display: inline-flex;
+    align-items: center;
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
+.timeline-title {
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+.timeline-title:hover {
+    text-decoration: underline;
+}
+
+.timeline-description {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    line-height: 1.4;
+}
+
+.timeline-load-more {
+    display: flex;
+    justify-content: center;
+    padding: var(--space-4) 0 var(--space-2);
+}
+
+.btn-load-more {
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-2) var(--space-4);
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.btn-load-more:hover {
+    background: var(--color-surface-hover, rgba(0, 0, 0, 0.04));
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}


### PR DESCRIPTION
## Summary
- Extracts inline appointment, meal plan, and progress sections from `ClientDetail.razor` into 4 dedicated widget components (`ProgressSummaryWidget`, `ActiveMealPlanCard`, `UpcomingAppointmentsWidget`, `VisitHistoryTimeline`) that each manage their own data loading
- Adds a responsive two-column grid layout for Progress Summary and Active Meal Plan, with full-width Upcoming Appointments and Visit History Timeline below
- Widgets refresh automatically via `@key`-based re-initialization when real-time entity change notifications arrive (now also listens for `ProgressEntry` changes)
- Removes 3 unused service injections and ~165 lines of inline markup from the parent page

## New Components
| Widget | Features |
|--------|----------|
| `ProgressSummaryWidget` | Weight trend with delta arrows via chart data, active goals list |
| `ActiveMealPlanCard` | Active/latest plan with calorie target, P/C/F macros, date range |
| `UpcomingAppointmentsWidget` | Next 3 appointments with countdown, location icons, inline cancel |
| `VisitHistoryTimeline` | Unified chronological feed from 3 domains, paginated (load 10 more) |

## Test plan
- [ ] Navigate to `/clients/{id}` with a client that has appointments, meal plans, and progress data — all 4 widgets render
- [ ] Navigate with a client that has no data — all empty states render correctly
- [ ] Resize browser to ≤768px — two-column grid stacks to single column
- [ ] Test edit/delete/consent flows still work
- [ ] Cancel an appointment from the widget — list refreshes
- [ ] Verify real-time updates trigger widget refresh

Closes #97, closes #102, closes #104, closes #106, closes #108, closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)