### PR TITLE
feat: add health profile UI to client pages

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
@@ -10,6 +10,7 @@
 @using Nutrir.Core.Interfaces
 @using Nutrir.Core.Models
 @using Nutrir.Infrastructure.Configuration
+@using Nutrir.Web.Components.Widgets
 @using Microsoft.Extensions.Options
 @using Nutrir.Web.Components.UI
 @attribute [Authorize(Roles = "Admin,Nutritionist,Assistant")]
@@ -18,6 +19,7 @@
 @inject IConsentFormTemplate ConsentFormTemplate
 @inject IOptions<ConsentFormOptions> ConsentFormOptionsAccessor
 @inject IUserManagementService UserManagementService
+@inject IClientHealthProfileService HealthProfileService
 @inject NavigationManager NavigationManager
 
 <PageTitle>New Client — Nutrir</PageTitle>
@@ -105,6 +107,12 @@
                               @bind="_model.Notes"
                               placeholder="Additional notes about the client..."></textarea>
                 </FormGroup>
+
+                @* ── Health Profile ───────────────────────────── *@
+                <AllergyFormGroup @ref="_allergyFormGroup" Entries="@_allergyEntries" />
+                <MedicationFormGroup @ref="_medicationFormGroup" Entries="@_medicationEntries" />
+                <ConditionFormGroup @ref="_conditionFormGroup" Entries="@_conditionEntries" />
+                <DietaryRestrictionFormGroup @ref="_dietaryRestrictionFormGroup" Entries="@_dietaryRestrictionEntries" />
 
                 @* ── Consent Section ──────────────────────────── *@
                 <div class="consent-section">
@@ -204,6 +212,16 @@
     private IReadOnlyList<Autocomplete.AutocompleteOption> _nutritionistOptions = [];
     private string? _nutritionistDisplayText;
     private ConsentFormContent? _consentContent;
+
+    // Health profile form groups
+    private AllergyFormGroup _allergyFormGroup = default!;
+    private MedicationFormGroup _medicationFormGroup = default!;
+    private ConditionFormGroup _conditionFormGroup = default!;
+    private DietaryRestrictionFormGroup _dietaryRestrictionFormGroup = default!;
+    private List<AllergyFormGroup.AllergyEntry> _allergyEntries = new();
+    private List<MedicationFormGroup.MedicationEntry> _medicationEntries = new();
+    private List<ConditionFormGroup.ConditionEntry> _conditionEntries = new();
+    private List<DietaryRestrictionFormGroup.DietaryRestrictionEntry> _dietaryRestrictionEntries = new();
 
     private bool _hasClientName =>
         !string.IsNullOrWhiteSpace(_model.FirstName) && !string.IsNullOrWhiteSpace(_model.LastName);
@@ -325,6 +343,9 @@
 
             var created = await ClientService.CreateAsync(dto, userId);
 
+            // Save health profile entries
+            await SaveHealthProfileAsync(created.Id, userId);
+
             // Record consent form based on method
             if (isDigital)
             {
@@ -340,6 +361,30 @@
         finally
         {
             _isSubmitting = false;
+        }
+    }
+
+    private async Task SaveHealthProfileAsync(int clientId, string userId)
+    {
+        foreach (var (name, severity, allergyType) in _allergyFormGroup.GetValidEntries())
+        {
+            await HealthProfileService.CreateAllergyAsync(
+                new CreateClientAllergyDto(clientId, name, severity, allergyType), userId);
+        }
+        foreach (var (name, dosage, frequency, prescribedFor) in _medicationFormGroup.GetValidEntries())
+        {
+            await HealthProfileService.CreateMedicationAsync(
+                new CreateClientMedicationDto(clientId, name, dosage, frequency, prescribedFor), userId);
+        }
+        foreach (var (name, code, diagnosisDate, status) in _conditionFormGroup.GetValidEntries())
+        {
+            await HealthProfileService.CreateConditionAsync(
+                new CreateClientConditionDto(clientId, name, code, diagnosisDate, status, null), userId);
+        }
+        foreach (var (restrictionType, notes) in _dietaryRestrictionFormGroup.GetValidEntries())
+        {
+            await HealthProfileService.CreateDietaryRestrictionAsync(
+                new CreateClientDietaryRestrictionDto(clientId, restrictionType, notes), userId);
         }
     }
 

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor.css
@@ -89,6 +89,78 @@
     gap: var(--space-4);
 }
 
+/* ── Health Form Sections ─────────────────────────────── */
+::deep .health-form-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding-top: var(--space-2);
+    border-top: 1px solid var(--color-border);
+}
+
+::deep .health-form-label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider);
+    color: var(--color-text-muted);
+}
+
+::deep .health-form-label svg {
+    opacity: 0.7;
+}
+
+::deep .health-form-entry {
+    position: relative;
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-bg-alt);
+}
+
+::deep .health-form-entry .form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-3);
+}
+
+::deep .health-form-remove {
+    position: absolute;
+    top: var(--space-2);
+    right: var(--space-2);
+    background: none;
+    border: none;
+    padding: var(--space-1);
+    cursor: pointer;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    transition: color var(--duration-fast) var(--ease-default);
+}
+
+::deep .health-form-remove:hover {
+    color: var(--color-error);
+}
+
+::deep .health-form-add {
+    background: none;
+    border: none;
+    padding: var(--space-1) 0;
+    cursor: pointer;
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--color-primary);
+    transition: opacity var(--duration-fast) var(--ease-default);
+}
+
+::deep .health-form-add:hover {
+    opacity: 0.8;
+}
+
 /* ── Consent Section ──────────────────────────────────── */
 .consent-section {
     display: flex;

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientDetail.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientDetail.razor
@@ -17,6 +17,7 @@
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject NavigationManager NavigationManager
 @inject ITimeZoneService TimeZoneService
+@inject IClientHealthProfileService HealthProfileService
 @inject RealTimeNotificationService NotificationService
 
 <PageTitle>@(_client is not null ? $"{_client.FirstName} {_client.LastName}" : "Client") — Nutrir</PageTitle>
@@ -177,24 +178,41 @@
             </div>
         }
 
+        @* ── Health Profile Sections ──────────────────────── *@
+        @if (_healthProfile is not null)
+        {
+            <div class="section-animate" style="animation-delay: 160ms;" @key="@($"allergies-{_refreshKey}")">
+                <AllergiesSection ClientId="@Id" InitialData="@_healthProfile.Allergies" />
+            </div>
+            <div class="section-animate" style="animation-delay: 200ms;" @key="@($"medications-{_refreshKey}")">
+                <MedicationsSection ClientId="@Id" InitialData="@_healthProfile.Medications" />
+            </div>
+            <div class="section-animate" style="animation-delay: 240ms;" @key="@($"conditions-{_refreshKey}")">
+                <ConditionsSection ClientId="@Id" InitialData="@_healthProfile.Conditions" />
+            </div>
+            <div class="section-animate" style="animation-delay: 280ms;" @key="@($"dietary-{_refreshKey}")">
+                <DietaryRestrictionsSection ClientId="@Id" InitialData="@_healthProfile.DietaryRestrictions" />
+            </div>
+        }
+
         @* ── Widget Grid: Progress + Meal Plan ─────────── *@
-        <div class="widget-grid section-animate" style="animation-delay: 160ms;">
+        <div class="widget-grid section-animate" style="animation-delay: 320ms;">
             <ProgressSummaryWidget ClientId="@Id" @key="@($"progress-{_refreshKey}")" />
             <ActiveMealPlanCard ClientId="@Id" @key="@($"mealplan-{_refreshKey}")" />
         </div>
 
         @* ── Upcoming Appointments Widget ──────────────── *@
-        <div class="section-animate" style="animation-delay: 240ms;">
+        <div class="section-animate" style="animation-delay: 400ms;">
             <UpcomingAppointmentsWidget ClientId="@Id" @key="@($"appointments-{_refreshKey}")" />
         </div>
 
         @* ── Visit History Timeline ────────────────────── *@
-        <div class="section-animate" style="animation-delay: 320ms;">
+        <div class="section-animate" style="animation-delay: 480ms;">
             <VisitHistoryTimeline ClientId="@Id" @key="@($"timeline-{_refreshKey}")" />
         </div>
 
         @* ── Consent Form ──────────────────────────────────── *@
-        <div class="table-card section-animate" style="animation-delay: 400ms;">
+        <div class="table-card section-animate" style="animation-delay: 560ms;">
             <div class="section-header">
                 <span class="section-header-label">Consent Form</span>
             </div>
@@ -263,7 +281,7 @@
         </div>
 
         @* ── Metadata Footer ─────────────────────────────── *@
-        <div class="meta-footer section-animate" style="animation-delay: 480ms;" @key="_refreshKey">
+        <div class="meta-footer section-animate" style="animation-delay: 640ms;" @key="_refreshKey">
             <span>Created: @_client.CreatedAt.ToString("MMM d, yyyy")</span>
             @if (_client.UpdatedAt.HasValue)
             {
@@ -280,6 +298,7 @@
 
     private ClientDto? _client;
     private ConsentFormDto? _latestConsentForm;
+    private ClientHealthProfileSummaryDto? _healthProfile;
     private int _refreshKey;
     private bool _isLoading = true;
     private bool _showDeleteConfirm;
@@ -296,6 +315,7 @@
         await TimeZoneService.InitializeAsync();
         _client = await ClientService.GetByIdAsync(Id);
         _latestConsentForm = await ConsentFormService.GetLatestFormAsync(Id);
+        _healthProfile = await HealthProfileService.GetHealthProfileSummaryAsync(Id);
         _isLoading = false;
 
         if (_client is not null)
@@ -309,7 +329,8 @@
     private void OnEntityChanged(EntityChangeNotification notification)
     {
         var isThisClient = notification.EntityType == "Client" && notification.EntityId == Id;
-        var isRelatedEntity = notification.EntityType is "MealPlan" or "Appointment" or "ProgressEntry";
+        var isRelatedEntity = notification.EntityType is "MealPlan" or "Appointment" or "ProgressEntry"
+            or "ClientAllergy" or "ClientMedication" or "ClientCondition" or "ClientDietaryRestriction";
 
         if (!isThisClient && !isRelatedEntity)
             return;
@@ -318,6 +339,7 @@
         {
             _client = await ClientService.GetByIdAsync(Id);
             _latestConsentForm = await ConsentFormService.GetLatestFormAsync(Id);
+            _healthProfile = await HealthProfileService.GetHealthProfileSummaryAsync(Id);
             _refreshKey++;
             _refreshedByRealTime = true;
             StateHasChanged();

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
@@ -6,15 +6,18 @@
 @using System.ComponentModel.DataAnnotations
 @using System.Security.Claims
 @using Nutrir.Core.DTOs
+@using Nutrir.Core.Enums
 @using Nutrir.Core.Interfaces
 @using Nutrir.Core.Models
 @using Nutrir.Web.Components.UI
+@using Nutrir.Web.Components.Widgets
 @attribute [Authorize(Roles = "Admin,Nutritionist,Assistant")]
 @inject IClientService ClientService
 @inject IConsentService ConsentService
 @inject IConsentFormService ConsentFormService
 @inject IConsentFormTemplate ConsentFormTemplate
 @inject IUserManagementService UserManagementService
+@inject IClientHealthProfileService HealthProfileService
 @inject NavigationManager NavigationManager
 
 <PageTitle>Edit Client — Nutrir</PageTitle>
@@ -124,6 +127,12 @@
                                   @bind="_model.Notes"
                                   placeholder="Additional notes about the client..."></textarea>
                     </FormGroup>
+
+                    @* ── Health Profile ───────────────────────────── *@
+                    <AllergyFormGroup @ref="_allergyFormGroup" Entries="@_allergyEntries" />
+                    <MedicationFormGroup @ref="_medicationFormGroup" Entries="@_medicationEntries" />
+                    <ConditionFormGroup @ref="_conditionFormGroup" Entries="@_conditionEntries" />
+                    <DietaryRestrictionFormGroup @ref="_dietaryRestrictionFormGroup" Entries="@_dietaryRestrictionEntries" />
 
                     <div class="consent-row">
                         <div class="consent-status">
@@ -236,6 +245,17 @@
     private IReadOnlyList<Autocomplete.AutocompleteOption> _nutritionistOptions = [];
     private string? _nutritionistDisplayText;
 
+    // Health profile
+    private ClientHealthProfileSummaryDto? _healthProfile;
+    private AllergyFormGroup _allergyFormGroup = default!;
+    private MedicationFormGroup _medicationFormGroup = default!;
+    private ConditionFormGroup _conditionFormGroup = default!;
+    private DietaryRestrictionFormGroup _dietaryRestrictionFormGroup = default!;
+    private List<AllergyFormGroup.AllergyEntry> _allergyEntries = new();
+    private List<MedicationFormGroup.MedicationEntry> _medicationEntries = new();
+    private List<ConditionFormGroup.ConditionEntry> _conditionEntries = new();
+    private List<DietaryRestrictionFormGroup.DietaryRestrictionEntry> _dietaryRestrictionEntries = new();
+
     protected override async Task OnInitializedAsync()
     {
         _client = await ClientService.GetByIdAsync(Id);
@@ -275,6 +295,34 @@
                     practitionerName,
                     DateTime.UtcNow);
             }
+
+            // Load health profile
+            _healthProfile = await HealthProfileService.GetHealthProfileSummaryAsync(Id);
+            _allergyEntries = _healthProfile.Allergies.Select(a => new AllergyFormGroup.AllergyEntry
+            {
+                Name = a.Name,
+                Severity = a.Severity,
+                AllergyType = a.AllergyType
+            }).ToList();
+            _medicationEntries = _healthProfile.Medications.Select(m => new MedicationFormGroup.MedicationEntry
+            {
+                Name = m.Name,
+                Dosage = m.Dosage,
+                Frequency = m.Frequency,
+                PrescribedFor = m.PrescribedFor
+            }).ToList();
+            _conditionEntries = _healthProfile.Conditions.Select(c => new ConditionFormGroup.ConditionEntry
+            {
+                Name = c.Name,
+                Code = c.Code,
+                DiagnosisDate = c.DiagnosisDate?.ToString("yyyy-MM-dd"),
+                Status = c.Status
+            }).ToList();
+            _dietaryRestrictionEntries = _healthProfile.DietaryRestrictions.Select(d => new DietaryRestrictionFormGroup.DietaryRestrictionEntry
+            {
+                RestrictionType = d.RestrictionType,
+                Notes = d.Notes
+            }).ToList();
         }
 
         _isLoading = false;
@@ -394,6 +442,8 @@
             var success = await ClientService.UpdateAsync(Id, dto, userId);
             if (success)
             {
+                // Save health profile changes (delete all existing, re-create from form)
+                await SaveHealthProfileChangesAsync(userId);
                 NavigationManager.NavigateTo($"/clients/{Id}");
             }
             else
@@ -408,6 +458,43 @@
         finally
         {
             _isSubmitting = false;
+        }
+    }
+
+    private async Task SaveHealthProfileChangesAsync(string userId)
+    {
+        if (_healthProfile is null) return;
+
+        // Delete all existing entries
+        foreach (var a in _healthProfile.Allergies)
+            await HealthProfileService.DeleteAllergyAsync(a.Id, userId);
+        foreach (var m in _healthProfile.Medications)
+            await HealthProfileService.DeleteMedicationAsync(m.Id, userId);
+        foreach (var c in _healthProfile.Conditions)
+            await HealthProfileService.DeleteConditionAsync(c.Id, userId);
+        foreach (var d in _healthProfile.DietaryRestrictions)
+            await HealthProfileService.DeleteDietaryRestrictionAsync(d.Id, userId);
+
+        // Re-create from form entries
+        foreach (var (name, severity, allergyType) in _allergyFormGroup.GetValidEntries())
+        {
+            await HealthProfileService.CreateAllergyAsync(
+                new CreateClientAllergyDto(Id, name, severity, allergyType), userId);
+        }
+        foreach (var (name, dosage, frequency, prescribedFor) in _medicationFormGroup.GetValidEntries())
+        {
+            await HealthProfileService.CreateMedicationAsync(
+                new CreateClientMedicationDto(Id, name, dosage, frequency, prescribedFor), userId);
+        }
+        foreach (var (name, code, diagnosisDate, status) in _conditionFormGroup.GetValidEntries())
+        {
+            await HealthProfileService.CreateConditionAsync(
+                new CreateClientConditionDto(Id, name, code, diagnosisDate, status, null), userId);
+        }
+        foreach (var (restrictionType, notes) in _dietaryRestrictionFormGroup.GetValidEntries())
+        {
+            await HealthProfileService.CreateDietaryRestrictionAsync(
+                new CreateClientDietaryRestrictionDto(Id, restrictionType, notes), userId);
         }
     }
 

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor.css
@@ -101,6 +101,78 @@
     gap: var(--space-4);
 }
 
+/* ── Health Form Sections ─────────────────────────────── */
+::deep .health-form-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding-top: var(--space-2);
+    border-top: 1px solid var(--color-border);
+}
+
+::deep .health-form-label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider);
+    color: var(--color-text-muted);
+}
+
+::deep .health-form-label svg {
+    opacity: 0.7;
+}
+
+::deep .health-form-entry {
+    position: relative;
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-bg-alt);
+}
+
+::deep .health-form-entry .form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-3);
+}
+
+::deep .health-form-remove {
+    position: absolute;
+    top: var(--space-2);
+    right: var(--space-2);
+    background: none;
+    border: none;
+    padding: var(--space-1);
+    cursor: pointer;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    transition: color var(--duration-fast) var(--ease-default);
+}
+
+::deep .health-form-remove:hover {
+    color: var(--color-error);
+}
+
+::deep .health-form-add {
+    background: none;
+    border: none;
+    padding: var(--space-1) 0;
+    cursor: pointer;
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--color-primary);
+    transition: opacity var(--duration-fast) var(--ease-default);
+}
+
+::deep .health-form-add:hover {
+    opacity: 0.8;
+}
+
 /* ── Consent Row ──────────────────────────────────────── */
 .consent-row {
     padding: var(--space-2) 0;

--- a/src/Nutrir.Web/Components/Widgets/AllergiesSection.razor
+++ b/src/Nutrir.Web/Components/Widgets/AllergiesSection.razor
@@ -1,0 +1,353 @@
+@using Nutrir.Core.DTOs
+@using Nutrir.Core.Enums
+@using Nutrir.Core.Interfaces
+@using Microsoft.AspNetCore.Components.Authorization
+@using System.Security.Claims
+
+@inject IClientHealthProfileService HealthProfileService
+
+<div class="table-card health-section">
+    <div class="section-header" @onclick="ToggleCollapsed" role="button" tabindex="0">
+        <div class="section-header-left">
+            <span class="section-header-label">Allergies</span>
+            <span class="section-count">(@_allergies.Count)</span>
+        </div>
+        <button class="section-toggle" aria-label="@(_collapsed ? "Expand" : "Collapse")">
+            <svg class="toggle-icon @(_collapsed ? "collapsed" : "")" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m4 6 4 4 4-4"/>
+            </svg>
+        </button>
+    </div>
+    @if (!_collapsed)
+    {
+        <div class="section-list">
+            @if (_allergies.Count == 0 && !_showAddForm)
+            {
+                <div class="section-empty">No allergies recorded</div>
+            }
+            else
+            {
+                @foreach (var allergy in _allergies)
+                {
+                    @if (_editingId == allergy.Id)
+                    {
+                        <div class="inline-form">
+                            <div class="inline-form-grid">
+                                <FormGroup Label="Name" Id="edit-allergy-name">
+                                    <FormInput Id="edit-allergy-name"
+                                               Value="@_editName"
+                                               ValueChanged="@(v => _editName = v)"
+                                               Placeholder="Allergy name" />
+                                </FormGroup>
+                                <FormGroup Label="Severity" Id="edit-allergy-severity">
+                                    <FormSelect Id="edit-allergy-severity"
+                                                Value="@_editSeverity.ToString()"
+                                                ValueChanged="@(v => _editSeverity = Enum.Parse<AllergySeverity>(v))">
+                                        @foreach (var s in Enum.GetValues<AllergySeverity>())
+                                        {
+                                            <option value="@s">@s</option>
+                                        }
+                                    </FormSelect>
+                                </FormGroup>
+                                <FormGroup Label="Type" Id="edit-allergy-type">
+                                    <FormSelect Id="edit-allergy-type"
+                                                Value="@_editAllergyType.ToString()"
+                                                ValueChanged="@(v => _editAllergyType = Enum.Parse<AllergyType>(v))">
+                                        @foreach (var t in Enum.GetValues<AllergyType>())
+                                        {
+                                            <option value="@t">@t</option>
+                                        }
+                                    </FormSelect>
+                                </FormGroup>
+                            </div>
+                            @if (!string.IsNullOrEmpty(_formError))
+                            {
+                                <p class="form-error">@_formError</p>
+                            }
+                            <div class="inline-form-actions">
+                                <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="SaveEdit" Disabled="@_isSaving">
+                                    @(_isSaving ? "Saving..." : "Save")
+                                </Button>
+                                <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelEdit">Cancel</Button>
+                            </div>
+                        </div>
+                    }
+                    else if (_deletingId == allergy.Id)
+                    {
+                        <div class="delete-confirm-row">
+                            <span class="delete-confirm-text">Delete <strong>@allergy.Name</strong>?</span>
+                            <div class="delete-confirm-actions">
+                                <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="ConfirmDelete" Disabled="@_isSaving">
+                                    @(_isSaving ? "Deleting..." : "Delete")
+                                </Button>
+                                <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelDelete">Cancel</Button>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="list-row">
+                            <div class="list-row-primary">
+                                <span class="list-row-title">@allergy.Name</span>
+                                <span class="list-row-meta">@allergy.AllergyType</span>
+                            </div>
+                            <div class="list-row-actions">
+                                <Badge Variant="@GetSeverityVariant(allergy.Severity)">
+                                    <span class="badge-dot"></span> @allergy.Severity
+                                </Badge>
+                                <button class="row-action" title="Edit" @onclick="@(() => StartEdit(allergy))">
+                                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 2.5a1.77 1.77 0 0 1 2.5 2.5L5.5 13.5l-3.5 1 1-3.5Z"/></svg>
+                                </button>
+                                <button class="row-action row-action-danger" title="Delete" @onclick="@(() => StartDelete(allergy.Id))">
+                                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5h10M6.5 7v4M9.5 7v4"/><path d="M4 4.5l.5 8.5a1.5 1.5 0 0 0 1.5 1.5h4a1.5 1.5 0 0 0 1.5-1.5l.5-8.5"/><path d="M6 4.5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1.5"/></svg>
+                                </button>
+                            </div>
+                        </div>
+                    }
+                }
+            }
+
+            @if (_showAddForm)
+            {
+                <div class="inline-form">
+                    <div class="inline-form-grid">
+                        <FormGroup Label="Name" Id="add-allergy-name">
+                            <FormInput Id="add-allergy-name"
+                                       Value="@_addName"
+                                       ValueChanged="@(v => _addName = v)"
+                                       Placeholder="Allergy name" />
+                        </FormGroup>
+                        <FormGroup Label="Severity" Id="add-allergy-severity">
+                            <FormSelect Id="add-allergy-severity"
+                                        Value="@_addSeverity.ToString()"
+                                        ValueChanged="@(v => _addSeverity = Enum.Parse<AllergySeverity>(v))">
+                                @foreach (var s in Enum.GetValues<AllergySeverity>())
+                                {
+                                    <option value="@s">@s</option>
+                                }
+                            </FormSelect>
+                        </FormGroup>
+                        <FormGroup Label="Type" Id="add-allergy-type">
+                            <FormSelect Id="add-allergy-type"
+                                        Value="@_addAllergyType.ToString()"
+                                        ValueChanged="@(v => _addAllergyType = Enum.Parse<AllergyType>(v))">
+                                @foreach (var t in Enum.GetValues<AllergyType>())
+                                {
+                                    <option value="@t">@t</option>
+                                }
+                            </FormSelect>
+                        </FormGroup>
+                    </div>
+                    @if (!string.IsNullOrEmpty(_formError))
+                    {
+                        <p class="form-error">@_formError</p>
+                    }
+                    <div class="inline-form-actions">
+                        <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="SaveAdd" Disabled="@_isSaving">
+                            @(_isSaving ? "Adding..." : "Add Allergy")
+                        </Button>
+                        <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelAdd">Cancel</Button>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="add-row">
+                    <button class="add-button" @onclick="ShowAddForm">+ Add Allergy</button>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public int ClientId { get; set; }
+    [Parameter] public List<ClientAllergyDto>? InitialData { get; set; }
+    [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
+
+    private List<ClientAllergyDto> _allergies = new();
+    private bool _collapsed;
+    private bool _showAddForm;
+    private bool _isSaving;
+    private string? _formError;
+
+    // Add form state
+    private string _addName = string.Empty;
+    private AllergySeverity _addSeverity = AllergySeverity.Mild;
+    private AllergyType _addAllergyType = AllergyType.Food;
+
+    // Edit form state
+    private int? _editingId;
+    private string _editName = string.Empty;
+    private AllergySeverity _editSeverity;
+    private AllergyType _editAllergyType;
+
+    // Delete state
+    private int? _deletingId;
+
+    protected override void OnParametersSet()
+    {
+        if (InitialData is not null)
+        {
+            _allergies = InitialData;
+        }
+    }
+
+    private void ToggleCollapsed() => _collapsed = !_collapsed;
+
+    private static BadgeVariant GetSeverityVariant(AllergySeverity severity) => severity switch
+    {
+        AllergySeverity.Mild => BadgeVariant.Success,
+        AllergySeverity.Moderate => BadgeVariant.Warning,
+        AllergySeverity.Severe => BadgeVariant.Error,
+        _ => BadgeVariant.Secondary
+    };
+
+    private async Task<string> GetUserIdAsync()
+    {
+        var authState = await AuthState;
+        return authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+    }
+
+    // --- Add ---
+    private void ShowAddForm()
+    {
+        _showAddForm = true;
+        _editingId = null;
+        _deletingId = null;
+        _formError = null;
+        _addName = string.Empty;
+        _addSeverity = AllergySeverity.Mild;
+        _addAllergyType = AllergyType.Food;
+    }
+
+    private void CancelAdd()
+    {
+        _showAddForm = false;
+        _formError = null;
+    }
+
+    private async Task SaveAdd()
+    {
+        if (string.IsNullOrWhiteSpace(_addName))
+        {
+            _formError = "Name is required.";
+            return;
+        }
+
+        _isSaving = true;
+        _formError = null;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            var dto = new CreateClientAllergyDto(ClientId, _addName.Trim(), _addSeverity, _addAllergyType);
+            var created = await HealthProfileService.CreateAllergyAsync(dto, userId);
+            _allergies.Add(created);
+            _showAddForm = false;
+            _addName = string.Empty;
+        }
+        catch
+        {
+            _formError = "Failed to add allergy. Please try again.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    // --- Edit ---
+    private void StartEdit(ClientAllergyDto allergy)
+    {
+        _editingId = allergy.Id;
+        _editName = allergy.Name;
+        _editSeverity = allergy.Severity;
+        _editAllergyType = allergy.AllergyType;
+        _deletingId = null;
+        _showAddForm = false;
+        _formError = null;
+    }
+
+    private void CancelEdit()
+    {
+        _editingId = null;
+        _formError = null;
+    }
+
+    private async Task SaveEdit()
+    {
+        if (string.IsNullOrWhiteSpace(_editName))
+        {
+            _formError = "Name is required.";
+            return;
+        }
+
+        _isSaving = true;
+        _formError = null;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            var dto = new UpdateClientAllergyDto(_editName.Trim(), _editSeverity, _editAllergyType);
+            var success = await HealthProfileService.UpdateAllergyAsync(_editingId!.Value, dto, userId);
+            if (success)
+            {
+                var updated = await HealthProfileService.GetAllergyByIdAsync(_editingId.Value);
+                if (updated is not null)
+                {
+                    var idx = _allergies.FindIndex(a => a.Id == _editingId.Value);
+                    if (idx >= 0) _allergies[idx] = updated;
+                }
+                _editingId = null;
+            }
+            else
+            {
+                _formError = "Failed to update allergy.";
+            }
+        }
+        catch
+        {
+            _formError = "Failed to update allergy. Please try again.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    // --- Delete ---
+    private void StartDelete(int id)
+    {
+        _deletingId = id;
+        _editingId = null;
+        _showAddForm = false;
+        _formError = null;
+    }
+
+    private void CancelDelete()
+    {
+        _deletingId = null;
+    }
+
+    private async Task ConfirmDelete()
+    {
+        _isSaving = true;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            var success = await HealthProfileService.DeleteAllergyAsync(_deletingId!.Value, userId);
+            if (success)
+            {
+                _allergies.RemoveAll(a => a.Id == _deletingId.Value);
+                _deletingId = null;
+            }
+        }
+        catch
+        {
+            _formError = "Failed to delete allergy.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+}

--- a/src/Nutrir.Web/Components/Widgets/AllergiesSection.razor.css
+++ b/src/Nutrir.Web/Components/Widgets/AllergiesSection.razor.css
@@ -1,0 +1,209 @@
+/* ── Health Section Card ──────────────────────────────── */
+.health-section {
+    background: var(--color-bg-card);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--color-border);
+    overflow: hidden;
+}
+
+.section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-bg-alt);
+    border-bottom: 1px solid var(--color-border);
+    cursor: pointer;
+    user-select: none;
+}
+
+.section-header-left {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.section-header-label {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+}
+
+.section-count {
+    font-size: var(--text-xs);
+    font-weight: 400;
+    color: var(--color-text-muted);
+}
+
+.section-toggle {
+    background: none;
+    border: none;
+    padding: var(--space-1);
+    cursor: pointer;
+    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+}
+
+.toggle-icon {
+    transition: transform var(--duration-fast) var(--ease-default);
+}
+
+.toggle-icon.collapsed {
+    transform: rotate(-90deg);
+}
+
+/* ── List ─────────────────────────────────────────────── */
+.section-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.section-empty {
+    padding: var(--space-8) var(--space-4);
+    text-align: center;
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+}
+
+.list-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    transition: background var(--duration-fast) var(--ease-default);
+}
+
+.list-row:hover {
+    background: var(--color-bg-alt);
+}
+
+.list-row-primary {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.list-row-title {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.list-row-meta {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+}
+
+.list-row-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+}
+
+.row-action {
+    background: none;
+    border: none;
+    padding: var(--space-1);
+    cursor: pointer;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    transition: color var(--duration-fast) var(--ease-default),
+                background var(--duration-fast) var(--ease-default);
+}
+
+.row-action:hover {
+    color: var(--color-primary);
+    background: var(--color-bg-alt);
+}
+
+.row-action-danger:hover {
+    color: var(--color-error);
+}
+
+/* ── Badge Dot ────────────────────────────────────────── */
+.badge-dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: var(--radius-full);
+    background: currentColor;
+}
+
+/* ── Inline Form ──────────────────────────────────────── */
+.inline-form {
+    padding: var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-bg-alt);
+}
+
+.inline-form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--space-3);
+}
+
+.inline-form-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+}
+
+.form-error {
+    font-size: var(--text-xs);
+    color: var(--color-error);
+    margin: var(--space-2) 0 0;
+}
+
+/* ── Delete Confirm Row ───────────────────────────────── */
+.delete-confirm-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-error) 5%, var(--color-bg-card));
+}
+
+.delete-confirm-text {
+    font-size: var(--text-sm);
+    color: var(--color-text);
+}
+
+.delete-confirm-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+}
+
+/* ── Add Row ──────────────────────────────────────────── */
+.add-row {
+    padding: var(--space-2) var(--space-4);
+}
+
+.add-button {
+    background: none;
+    border: none;
+    padding: var(--space-1) 0;
+    cursor: pointer;
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--color-primary);
+    transition: opacity var(--duration-fast) var(--ease-default);
+}
+
+.add-button:hover {
+    opacity: 0.8;
+}

--- a/src/Nutrir.Web/Components/Widgets/AllergyFormGroup.razor
+++ b/src/Nutrir.Web/Components/Widgets/AllergyFormGroup.razor
@@ -1,0 +1,80 @@
+@using Nutrir.Core.Enums
+
+<div class="health-form-section">
+    <div class="health-form-label">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M18 6 6 18M6 6l12 12"/>
+        </svg>
+        <span>Allergies</span>
+    </div>
+
+    @foreach (var entry in Entries)
+    {
+        var index = Entries.IndexOf(entry);
+        <div class="health-form-entry">
+            <div class="form-grid">
+                <FormGroup Label="Allergy Name" Id="@($"allergy-name-{index}")">
+                    <FormInput Id="@($"allergy-name-{index}")"
+                               Value="@entry.Name"
+                               ValueChanged="@(v => entry.Name = v)"
+                               Placeholder="e.g. Peanuts" />
+                </FormGroup>
+                <FormGroup Label="Severity" Id="@($"allergy-severity-{index}")">
+                    <FormSelect Id="@($"allergy-severity-{index}")"
+                                Value="@entry.Severity.ToString()"
+                                ValueChanged="@(v => entry.Severity = Enum.Parse<AllergySeverity>(v))">
+                        @foreach (var s in Enum.GetValues<AllergySeverity>())
+                        {
+                            <option value="@s">@s</option>
+                        }
+                    </FormSelect>
+                </FormGroup>
+                <FormGroup Label="Type" Id="@($"allergy-type-{index}")">
+                    <FormSelect Id="@($"allergy-type-{index}")"
+                                Value="@entry.AllergyType.ToString()"
+                                ValueChanged="@(v => entry.AllergyType = Enum.Parse<AllergyType>(v))">
+                        @foreach (var t in Enum.GetValues<AllergyType>())
+                        {
+                            <option value="@t">@t</option>
+                        }
+                    </FormSelect>
+                </FormGroup>
+            </div>
+            <button class="health-form-remove" type="button" @onclick="@(() => Remove(index))" title="Remove">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5h10M6.5 7v4M9.5 7v4"/><path d="M4 4.5l.5 8.5a1.5 1.5 0 0 0 1.5 1.5h4a1.5 1.5 0 0 0 1.5-1.5l.5-8.5"/><path d="M6 4.5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1.5"/></svg>
+            </button>
+        </div>
+    }
+
+    <button class="health-form-add" type="button" @onclick="Add">+ Add Allergy</button>
+</div>
+
+@code {
+    [Parameter] public List<AllergyEntry> Entries { get; set; } = new();
+
+    private void Add()
+    {
+        Entries.Add(new AllergyEntry());
+    }
+
+    private void Remove(int index)
+    {
+        if (index >= 0 && index < Entries.Count)
+            Entries.RemoveAt(index);
+    }
+
+    public List<(string Name, AllergySeverity Severity, AllergyType AllergyType)> GetValidEntries()
+    {
+        return Entries
+            .Where(e => !string.IsNullOrWhiteSpace(e.Name))
+            .Select(e => (e.Name!.Trim(), e.Severity, e.AllergyType))
+            .ToList();
+    }
+
+    public class AllergyEntry
+    {
+        public string? Name { get; set; }
+        public AllergySeverity Severity { get; set; } = AllergySeverity.Mild;
+        public AllergyType AllergyType { get; set; } = AllergyType.Food;
+    }
+}

--- a/src/Nutrir.Web/Components/Widgets/ConditionFormGroup.razor
+++ b/src/Nutrir.Web/Components/Widgets/ConditionFormGroup.razor
@@ -1,0 +1,93 @@
+@using Nutrir.Core.Enums
+
+<div class="health-form-section">
+    <div class="health-form-label">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
+        </svg>
+        <span>Conditions</span>
+    </div>
+
+    @foreach (var entry in Entries)
+    {
+        var index = Entries.IndexOf(entry);
+        <div class="health-form-entry">
+            <div class="form-grid">
+                <FormGroup Label="Condition Name" Id="@($"cond-name-{index}")">
+                    <FormInput Id="@($"cond-name-{index}")"
+                               Value="@entry.Name"
+                               ValueChanged="@(v => entry.Name = v)"
+                               Placeholder="e.g. Type 2 Diabetes" />
+                </FormGroup>
+                <FormGroup Label="Code" Id="@($"cond-code-{index}")">
+                    <FormInput Id="@($"cond-code-{index}")"
+                               Value="@entry.Code"
+                               ValueChanged="@(v => entry.Code = v)"
+                               Placeholder="e.g. E11" />
+                </FormGroup>
+                <FormGroup Label="Diagnosis Date" Id="@($"cond-date-{index}")">
+                    <FormInput Id="@($"cond-date-{index}")"
+                               Type="date"
+                               Value="@entry.DiagnosisDate"
+                               ValueChanged="@(v => entry.DiagnosisDate = v)" />
+                </FormGroup>
+                <FormGroup Label="Status" Id="@($"cond-status-{index}")">
+                    <FormSelect Id="@($"cond-status-{index}")"
+                                Value="@entry.Status.ToString()"
+                                ValueChanged="@(v => entry.Status = Enum.Parse<ConditionStatus>(v))">
+                        @foreach (var s in Enum.GetValues<ConditionStatus>())
+                        {
+                            <option value="@s">@s</option>
+                        }
+                    </FormSelect>
+                </FormGroup>
+            </div>
+            <button class="health-form-remove" type="button" @onclick="@(() => Remove(index))" title="Remove">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5h10M6.5 7v4M9.5 7v4"/><path d="M4 4.5l.5 8.5a1.5 1.5 0 0 0 1.5 1.5h4a1.5 1.5 0 0 0 1.5-1.5l.5-8.5"/><path d="M6 4.5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1.5"/></svg>
+            </button>
+        </div>
+    }
+
+    <button class="health-form-add" type="button" @onclick="Add">+ Add Condition</button>
+</div>
+
+@code {
+    [Parameter] public List<ConditionEntry> Entries { get; set; } = new();
+
+    private void Add()
+    {
+        Entries.Add(new ConditionEntry());
+    }
+
+    private void Remove(int index)
+    {
+        if (index >= 0 && index < Entries.Count)
+            Entries.RemoveAt(index);
+    }
+
+    public List<(string Name, string? Code, DateOnly? DiagnosisDate, ConditionStatus Status)> GetValidEntries()
+    {
+        return Entries
+            .Where(e => !string.IsNullOrWhiteSpace(e.Name))
+            .Select(e => (
+                e.Name!.Trim(),
+                NullIfEmpty(e.Code),
+                ParseDate(e.DiagnosisDate),
+                e.Status))
+            .ToList();
+    }
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static DateOnly? ParseDate(string? value) =>
+        !string.IsNullOrEmpty(value) && DateOnly.TryParse(value, out var d) ? d : null;
+
+    public class ConditionEntry
+    {
+        public string? Name { get; set; }
+        public string? Code { get; set; }
+        public string? DiagnosisDate { get; set; }
+        public ConditionStatus Status { get; set; } = ConditionStatus.Active;
+    }
+}

--- a/src/Nutrir.Web/Components/Widgets/ConditionsSection.razor
+++ b/src/Nutrir.Web/Components/Widgets/ConditionsSection.razor
@@ -1,0 +1,365 @@
+@using Nutrir.Core.DTOs
+@using Nutrir.Core.Enums
+@using Nutrir.Core.Interfaces
+@using Microsoft.AspNetCore.Components.Authorization
+@using System.Security.Claims
+
+@inject IClientHealthProfileService HealthProfileService
+
+<div class="table-card health-section">
+    <div class="section-header" @onclick="ToggleCollapsed" role="button" tabindex="0">
+        <div class="section-header-left">
+            <span class="section-header-label">Conditions</span>
+            <span class="section-count">(@_conditions.Count)</span>
+        </div>
+        <button class="section-toggle" aria-label="@(_collapsed ? "Expand" : "Collapse")">
+            <svg class="toggle-icon @(_collapsed ? "collapsed" : "")" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m4 6 4 4 4-4"/>
+            </svg>
+        </button>
+    </div>
+    @if (!_collapsed)
+    {
+        <div class="section-list">
+            @if (_conditions.Count == 0 && !_showAddForm)
+            {
+                <div class="section-empty">No conditions recorded</div>
+            }
+            else
+            {
+                @foreach (var condition in _conditions)
+                {
+                    @if (_editingId == condition.Id)
+                    {
+                        <div class="inline-form">
+                            <div class="inline-form-grid">
+                                <FormGroup Label="Name" Id="edit-cond-name">
+                                    <FormInput Id="edit-cond-name"
+                                               Value="@_editName"
+                                               ValueChanged="@(v => _editName = v)"
+                                               Placeholder="Condition name" />
+                                </FormGroup>
+                                <FormGroup Label="Code" Id="edit-cond-code">
+                                    <FormInput Id="edit-cond-code"
+                                               Value="@_editCode"
+                                               ValueChanged="@(v => _editCode = v)"
+                                               Placeholder="e.g. ICD-10 code" />
+                                </FormGroup>
+                                <FormGroup Label="Diagnosis Date" Id="edit-cond-date">
+                                    <FormInput Id="edit-cond-date"
+                                               Type="date"
+                                               Value="@_editDiagnosisDate"
+                                               ValueChanged="@(v => _editDiagnosisDate = v)" />
+                                </FormGroup>
+                                <FormGroup Label="Status" Id="edit-cond-status">
+                                    <FormSelect Id="edit-cond-status"
+                                                Value="@_editStatus.ToString()"
+                                                ValueChanged="@(v => _editStatus = Enum.Parse<ConditionStatus>(v))">
+                                        @foreach (var s in Enum.GetValues<ConditionStatus>())
+                                        {
+                                            <option value="@s">@s</option>
+                                        }
+                                    </FormSelect>
+                                </FormGroup>
+                            </div>
+                            <FormGroup Label="Notes" Id="edit-cond-notes">
+                                <textarea id="edit-cond-notes" class="form-input" rows="2"
+                                          @bind="_editNotes" placeholder="Additional notes..."></textarea>
+                            </FormGroup>
+                            @if (!string.IsNullOrEmpty(_formError))
+                            {
+                                <p class="form-error">@_formError</p>
+                            }
+                            <div class="inline-form-actions">
+                                <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="SaveEdit" Disabled="@_isSaving">
+                                    @(_isSaving ? "Saving..." : "Save")
+                                </Button>
+                                <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelEdit">Cancel</Button>
+                            </div>
+                        </div>
+                    }
+                    else if (_deletingId == condition.Id)
+                    {
+                        <div class="delete-confirm-row">
+                            <span class="delete-confirm-text">Delete <strong>@condition.Name</strong>?</span>
+                            <div class="delete-confirm-actions">
+                                <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="ConfirmDelete" Disabled="@_isSaving">
+                                    @(_isSaving ? "Deleting..." : "Delete")
+                                </Button>
+                                <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelDelete">Cancel</Button>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="list-row">
+                            <div class="list-row-primary">
+                                <span class="list-row-title">
+                                    @condition.Name
+                                    @if (!string.IsNullOrEmpty(condition.Code))
+                                    {
+                                        <span class="condition-code">(@condition.Code)</span>
+                                    }
+                                </span>
+                                <span class="list-row-meta">
+                                    @if (condition.DiagnosisDate.HasValue)
+                                    {
+                                        <span>Diagnosed @condition.DiagnosisDate.Value.ToString("MMM d, yyyy")</span>
+                                    }
+                                    @if (!string.IsNullOrEmpty(condition.Notes))
+                                    {
+                                        @if (condition.DiagnosisDate.HasValue)
+                                        {
+                                            <span> · </span>
+                                        }
+                                        @condition.Notes
+                                    }
+                                </span>
+                            </div>
+                            <div class="list-row-actions">
+                                <Badge Variant="@GetStatusVariant(condition.Status)">
+                                    <span class="badge-dot"></span> @condition.Status
+                                </Badge>
+                                <button class="row-action" title="Edit" @onclick="@(() => StartEdit(condition))">
+                                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 2.5a1.77 1.77 0 0 1 2.5 2.5L5.5 13.5l-3.5 1 1-3.5Z"/></svg>
+                                </button>
+                                <button class="row-action row-action-danger" title="Delete" @onclick="@(() => StartDelete(condition.Id))">
+                                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5h10M6.5 7v4M9.5 7v4"/><path d="M4 4.5l.5 8.5a1.5 1.5 0 0 0 1.5 1.5h4a1.5 1.5 0 0 0 1.5-1.5l.5-8.5"/><path d="M6 4.5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1.5"/></svg>
+                                </button>
+                            </div>
+                        </div>
+                    }
+                }
+            }
+
+            @if (_showAddForm)
+            {
+                <div class="inline-form">
+                    <div class="inline-form-grid">
+                        <FormGroup Label="Name" Id="add-cond-name">
+                            <FormInput Id="add-cond-name"
+                                       Value="@_addName"
+                                       ValueChanged="@(v => _addName = v)"
+                                       Placeholder="Condition name" />
+                        </FormGroup>
+                        <FormGroup Label="Code" Id="add-cond-code">
+                            <FormInput Id="add-cond-code"
+                                       Value="@_addCode"
+                                       ValueChanged="@(v => _addCode = v)"
+                                       Placeholder="e.g. ICD-10 code" />
+                        </FormGroup>
+                        <FormGroup Label="Diagnosis Date" Id="add-cond-date">
+                            <FormInput Id="add-cond-date"
+                                       Type="date"
+                                       Value="@_addDiagnosisDate"
+                                       ValueChanged="@(v => _addDiagnosisDate = v)" />
+                        </FormGroup>
+                        <FormGroup Label="Status" Id="add-cond-status">
+                            <FormSelect Id="add-cond-status"
+                                        Value="@_addStatus.ToString()"
+                                        ValueChanged="@(v => _addStatus = Enum.Parse<ConditionStatus>(v))">
+                                @foreach (var s in Enum.GetValues<ConditionStatus>())
+                                {
+                                    <option value="@s">@s</option>
+                                }
+                            </FormSelect>
+                        </FormGroup>
+                    </div>
+                    <FormGroup Label="Notes" Id="add-cond-notes">
+                        <textarea id="add-cond-notes" class="form-input" rows="2"
+                                  @bind="_addNotes" placeholder="Additional notes..."></textarea>
+                    </FormGroup>
+                    @if (!string.IsNullOrEmpty(_formError))
+                    {
+                        <p class="form-error">@_formError</p>
+                    }
+                    <div class="inline-form-actions">
+                        <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="SaveAdd" Disabled="@_isSaving">
+                            @(_isSaving ? "Adding..." : "Add Condition")
+                        </Button>
+                        <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelAdd">Cancel</Button>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="add-row">
+                    <button class="add-button" @onclick="ShowAddForm">+ Add Condition</button>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public int ClientId { get; set; }
+    [Parameter] public List<ClientConditionDto>? InitialData { get; set; }
+    [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
+
+    private List<ClientConditionDto> _conditions = new();
+    private bool _collapsed;
+    private bool _showAddForm;
+    private bool _isSaving;
+    private string? _formError;
+
+    // Add form
+    private string _addName = string.Empty;
+    private string _addCode = string.Empty;
+    private string _addDiagnosisDate = string.Empty;
+    private ConditionStatus _addStatus = ConditionStatus.Active;
+    private string _addNotes = string.Empty;
+
+    // Edit form
+    private int? _editingId;
+    private string _editName = string.Empty;
+    private string _editCode = string.Empty;
+    private string _editDiagnosisDate = string.Empty;
+    private ConditionStatus _editStatus;
+    private string _editNotes = string.Empty;
+
+    // Delete
+    private int? _deletingId;
+
+    protected override void OnParametersSet()
+    {
+        if (InitialData is not null)
+            _conditions = InitialData;
+    }
+
+    private void ToggleCollapsed() => _collapsed = !_collapsed;
+
+    private static BadgeVariant GetStatusVariant(ConditionStatus status) => status switch
+    {
+        ConditionStatus.Active => BadgeVariant.Error,
+        ConditionStatus.Managed => BadgeVariant.Warning,
+        ConditionStatus.Resolved => BadgeVariant.Success,
+        _ => BadgeVariant.Secondary
+    };
+
+    private async Task<string> GetUserIdAsync()
+    {
+        var authState = await AuthState;
+        return authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+    }
+
+    private static DateOnly? ParseDate(string value) =>
+        !string.IsNullOrEmpty(value) && DateOnly.TryParse(value, out var d) ? d : null;
+
+    private void ShowAddForm()
+    {
+        _showAddForm = true;
+        _editingId = null;
+        _deletingId = null;
+        _formError = null;
+        _addName = string.Empty;
+        _addCode = string.Empty;
+        _addDiagnosisDate = string.Empty;
+        _addStatus = ConditionStatus.Active;
+        _addNotes = string.Empty;
+    }
+
+    private void CancelAdd() { _showAddForm = false; _formError = null; }
+
+    private async Task SaveAdd()
+    {
+        if (string.IsNullOrWhiteSpace(_addName))
+        {
+            _formError = "Name is required.";
+            return;
+        }
+        _isSaving = true;
+        _formError = null;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            var dto = new CreateClientConditionDto(
+                ClientId, _addName.Trim(),
+                NullIfEmpty(_addCode), ParseDate(_addDiagnosisDate),
+                _addStatus, NullIfEmpty(_addNotes));
+            var created = await HealthProfileService.CreateConditionAsync(dto, userId);
+            _conditions.Add(created);
+            _showAddForm = false;
+        }
+        catch
+        {
+            _formError = "Failed to add condition. Please try again.";
+        }
+        finally { _isSaving = false; }
+    }
+
+    private void StartEdit(ClientConditionDto c)
+    {
+        _editingId = c.Id;
+        _editName = c.Name;
+        _editCode = c.Code ?? string.Empty;
+        _editDiagnosisDate = c.DiagnosisDate?.ToString("yyyy-MM-dd") ?? string.Empty;
+        _editStatus = c.Status;
+        _editNotes = c.Notes ?? string.Empty;
+        _deletingId = null;
+        _showAddForm = false;
+        _formError = null;
+    }
+
+    private void CancelEdit() { _editingId = null; _formError = null; }
+
+    private async Task SaveEdit()
+    {
+        if (string.IsNullOrWhiteSpace(_editName))
+        {
+            _formError = "Name is required.";
+            return;
+        }
+        _isSaving = true;
+        _formError = null;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            var dto = new UpdateClientConditionDto(
+                _editName.Trim(), NullIfEmpty(_editCode),
+                ParseDate(_editDiagnosisDate), _editStatus, NullIfEmpty(_editNotes));
+            var success = await HealthProfileService.UpdateConditionAsync(_editingId!.Value, dto, userId);
+            if (success)
+            {
+                var updated = await HealthProfileService.GetConditionByIdAsync(_editingId.Value);
+                if (updated is not null)
+                {
+                    var idx = _conditions.FindIndex(c => c.Id == _editingId.Value);
+                    if (idx >= 0) _conditions[idx] = updated;
+                }
+                _editingId = null;
+            }
+            else { _formError = "Failed to update condition."; }
+        }
+        catch { _formError = "Failed to update condition. Please try again."; }
+        finally { _isSaving = false; }
+    }
+
+    private void StartDelete(int id)
+    {
+        _deletingId = id;
+        _editingId = null;
+        _showAddForm = false;
+        _formError = null;
+    }
+
+    private void CancelDelete() => _deletingId = null;
+
+    private async Task ConfirmDelete()
+    {
+        _isSaving = true;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            if (await HealthProfileService.DeleteConditionAsync(_deletingId!.Value, userId))
+            {
+                _conditions.RemoveAll(c => c.Id == _deletingId.Value);
+                _deletingId = null;
+            }
+        }
+        catch { _formError = "Failed to delete condition."; }
+        finally { _isSaving = false; }
+    }
+
+    private static string? NullIfEmpty(string value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Nutrir.Web/Components/Widgets/ConditionsSection.razor.css
+++ b/src/Nutrir.Web/Components/Widgets/ConditionsSection.razor.css
@@ -1,0 +1,217 @@
+/* ── Health Section Card ──────────────────────────────── */
+.health-section {
+    background: var(--color-bg-card);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--color-border);
+    overflow: hidden;
+}
+
+.section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-bg-alt);
+    border-bottom: 1px solid var(--color-border);
+    cursor: pointer;
+    user-select: none;
+}
+
+.section-header-left {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.section-header-label {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+}
+
+.section-count {
+    font-size: var(--text-xs);
+    font-weight: 400;
+    color: var(--color-text-muted);
+}
+
+.section-toggle {
+    background: none;
+    border: none;
+    padding: var(--space-1);
+    cursor: pointer;
+    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+}
+
+.toggle-icon {
+    transition: transform var(--duration-fast) var(--ease-default);
+}
+
+.toggle-icon.collapsed {
+    transform: rotate(-90deg);
+}
+
+/* ── List ─────────────────────────────────────────────── */
+.section-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.section-empty {
+    padding: var(--space-8) var(--space-4);
+    text-align: center;
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+}
+
+.list-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    transition: background var(--duration-fast) var(--ease-default);
+}
+
+.list-row:hover {
+    background: var(--color-bg-alt);
+}
+
+.list-row-primary {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.list-row-title {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.list-row-meta {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+}
+
+.list-row-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+}
+
+.row-action {
+    background: none;
+    border: none;
+    padding: var(--space-1);
+    cursor: pointer;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    transition: color var(--duration-fast) var(--ease-default),
+                background var(--duration-fast) var(--ease-default);
+}
+
+.row-action:hover {
+    color: var(--color-primary);
+    background: var(--color-bg-alt);
+}
+
+.row-action-danger:hover {
+    color: var(--color-error);
+}
+
+/* ── Badge Dot ────────────────────────────────────────── */
+.badge-dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: var(--radius-full);
+    background: currentColor;
+}
+
+/* ── Inline Form ──────────────────────────────────────── */
+.inline-form {
+    padding: var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-bg-alt);
+}
+
+.inline-form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--space-3);
+}
+
+.inline-form-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+}
+
+.form-error {
+    font-size: var(--text-xs);
+    color: var(--color-error);
+    margin: var(--space-2) 0 0;
+}
+
+/* ── Delete Confirm Row ───────────────────────────────── */
+.delete-confirm-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-error) 5%, var(--color-bg-card));
+}
+
+.delete-confirm-text {
+    font-size: var(--text-sm);
+    color: var(--color-text);
+}
+
+.delete-confirm-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+}
+
+/* ── Add Row ──────────────────────────────────────────── */
+.add-row {
+    padding: var(--space-2) var(--space-4);
+}
+
+.add-button {
+    background: none;
+    border: none;
+    padding: var(--space-1) 0;
+    cursor: pointer;
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--color-primary);
+    transition: opacity var(--duration-fast) var(--ease-default);
+}
+
+.add-button:hover {
+    opacity: 0.8;
+}
+
+/* ── Condition-specific ───────────────────────────────── */
+.condition-code {
+    font-weight: 400;
+    color: var(--color-text-muted);
+    font-size: var(--text-xs);
+    margin-left: var(--space-1);
+}

--- a/src/Nutrir.Web/Components/Widgets/DietaryRestrictionFormGroup.razor
+++ b/src/Nutrir.Web/Components/Widgets/DietaryRestrictionFormGroup.razor
@@ -1,0 +1,81 @@
+@using Nutrir.Core.Enums
+
+<div class="health-form-section">
+    <div class="health-form-label">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M17 21a1 1 0 0 0 1-1v-5.35c0-.457.316-.844.727-1.041a4 4 0 0 0-2.134-7.589 5 5 0 0 0-9.186 0 4 4 0 0 0-2.134 7.588c.411.198.727.585.727 1.041V20a1 1 0 0 0 1 1Z"/>
+            <path d="M12 8v13"/>
+        </svg>
+        <span>Dietary Restrictions</span>
+    </div>
+
+    @foreach (var entry in Entries)
+    {
+        var index = Entries.IndexOf(entry);
+        <div class="health-form-entry">
+            <div class="form-grid">
+                <FormGroup Label="Restriction Type" Id="@($"dr-type-{index}")">
+                    <FormSelect Id="@($"dr-type-{index}")"
+                                Value="@entry.RestrictionType.ToString()"
+                                ValueChanged="@(v => entry.RestrictionType = Enum.Parse<DietaryRestrictionType>(v))">
+                        @foreach (var t in Enum.GetValues<DietaryRestrictionType>())
+                        {
+                            <option value="@t">@FormatRestrictionType(t)</option>
+                        }
+                    </FormSelect>
+                </FormGroup>
+                <FormGroup Label="Notes" Id="@($"dr-notes-{index}")">
+                    <FormInput Id="@($"dr-notes-{index}")"
+                               Value="@entry.Notes"
+                               ValueChanged="@(v => entry.Notes = v)"
+                               Placeholder="Additional details" />
+                </FormGroup>
+            </div>
+            <button class="health-form-remove" type="button" @onclick="@(() => Remove(index))" title="Remove">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5h10M6.5 7v4M9.5 7v4"/><path d="M4 4.5l.5 8.5a1.5 1.5 0 0 0 1.5 1.5h4a1.5 1.5 0 0 0 1.5-1.5l.5-8.5"/><path d="M6 4.5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1.5"/></svg>
+            </button>
+        </div>
+    }
+
+    <button class="health-form-add" type="button" @onclick="Add">+ Add Restriction</button>
+</div>
+
+@code {
+    [Parameter] public List<DietaryRestrictionEntry> Entries { get; set; } = new();
+
+    private void Add()
+    {
+        Entries.Add(new DietaryRestrictionEntry());
+    }
+
+    private void Remove(int index)
+    {
+        if (index >= 0 && index < Entries.Count)
+            Entries.RemoveAt(index);
+    }
+
+    public List<(DietaryRestrictionType RestrictionType, string? Notes)> GetValidEntries()
+    {
+        return Entries
+            .Select(e => (e.RestrictionType, NullIfEmpty(e.Notes)))
+            .ToList();
+    }
+
+    private static string FormatRestrictionType(DietaryRestrictionType type) => type switch
+    {
+        DietaryRestrictionType.GlutenFree => "Gluten-Free",
+        DietaryRestrictionType.DairyFree => "Dairy-Free",
+        DietaryRestrictionType.LowSodium => "Low Sodium",
+        DietaryRestrictionType.NutFree => "Nut-Free",
+        _ => type.ToString()
+    };
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public class DietaryRestrictionEntry
+    {
+        public DietaryRestrictionType RestrictionType { get; set; } = DietaryRestrictionType.Vegetarian;
+        public string? Notes { get; set; }
+    }
+}

--- a/src/Nutrir.Web/Components/Widgets/DietaryRestrictionsSection.razor
+++ b/src/Nutrir.Web/Components/Widgets/DietaryRestrictionsSection.razor
@@ -1,0 +1,285 @@
+@using Nutrir.Core.DTOs
+@using Nutrir.Core.Enums
+@using Nutrir.Core.Interfaces
+@using Microsoft.AspNetCore.Components.Authorization
+@using System.Security.Claims
+
+@inject IClientHealthProfileService HealthProfileService
+
+<div class="table-card health-section">
+    <div class="section-header" @onclick="ToggleCollapsed" role="button" tabindex="0">
+        <div class="section-header-left">
+            <span class="section-header-label">Dietary Restrictions</span>
+            <span class="section-count">(@_restrictions.Count)</span>
+        </div>
+        <button class="section-toggle" aria-label="@(_collapsed ? "Expand" : "Collapse")">
+            <svg class="toggle-icon @(_collapsed ? "collapsed" : "")" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m4 6 4 4 4-4"/>
+            </svg>
+        </button>
+    </div>
+    @if (!_collapsed)
+    {
+        <div class="section-list">
+            @if (_restrictions.Count == 0 && !_showAddForm)
+            {
+                <div class="section-empty">No dietary restrictions recorded</div>
+            }
+            else
+            {
+                @foreach (var restriction in _restrictions)
+                {
+                    @if (_editingId == restriction.Id)
+                    {
+                        <div class="inline-form">
+                            <div class="inline-form-grid">
+                                <FormGroup Label="Type" Id="edit-dr-type">
+                                    <FormSelect Id="edit-dr-type"
+                                                Value="@_editType.ToString()"
+                                                ValueChanged="@(v => _editType = Enum.Parse<DietaryRestrictionType>(v))">
+                                        @foreach (var t in Enum.GetValues<DietaryRestrictionType>())
+                                        {
+                                            <option value="@t">@FormatRestrictionType(t)</option>
+                                        }
+                                    </FormSelect>
+                                </FormGroup>
+                                <FormGroup Label="Notes" Id="edit-dr-notes">
+                                    <FormInput Id="edit-dr-notes"
+                                               Value="@_editNotes"
+                                               ValueChanged="@(v => _editNotes = v)"
+                                               Placeholder="Additional details" />
+                                </FormGroup>
+                            </div>
+                            @if (!string.IsNullOrEmpty(_formError))
+                            {
+                                <p class="form-error">@_formError</p>
+                            }
+                            <div class="inline-form-actions">
+                                <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="SaveEdit" Disabled="@_isSaving">
+                                    @(_isSaving ? "Saving..." : "Save")
+                                </Button>
+                                <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelEdit">Cancel</Button>
+                            </div>
+                        </div>
+                    }
+                    else if (_deletingId == restriction.Id)
+                    {
+                        <div class="delete-confirm-row">
+                            <span class="delete-confirm-text">Delete <strong>@FormatRestrictionType(restriction.RestrictionType)</strong>?</span>
+                            <div class="delete-confirm-actions">
+                                <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="ConfirmDelete" Disabled="@_isSaving">
+                                    @(_isSaving ? "Deleting..." : "Delete")
+                                </Button>
+                                <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelDelete">Cancel</Button>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="list-row">
+                            <div class="list-row-primary">
+                                <span class="list-row-title">@FormatRestrictionType(restriction.RestrictionType)</span>
+                                @if (!string.IsNullOrEmpty(restriction.Notes))
+                                {
+                                    <span class="list-row-meta">@restriction.Notes</span>
+                                }
+                            </div>
+                            <div class="list-row-actions">
+                                <button class="row-action" title="Edit" @onclick="@(() => StartEdit(restriction))">
+                                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 2.5a1.77 1.77 0 0 1 2.5 2.5L5.5 13.5l-3.5 1 1-3.5Z"/></svg>
+                                </button>
+                                <button class="row-action row-action-danger" title="Delete" @onclick="@(() => StartDelete(restriction.Id))">
+                                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5h10M6.5 7v4M9.5 7v4"/><path d="M4 4.5l.5 8.5a1.5 1.5 0 0 0 1.5 1.5h4a1.5 1.5 0 0 0 1.5-1.5l.5-8.5"/><path d="M6 4.5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1.5"/></svg>
+                                </button>
+                            </div>
+                        </div>
+                    }
+                }
+            }
+
+            @if (_showAddForm)
+            {
+                <div class="inline-form">
+                    <div class="inline-form-grid">
+                        <FormGroup Label="Type" Id="add-dr-type">
+                            <FormSelect Id="add-dr-type"
+                                        Value="@_addType.ToString()"
+                                        ValueChanged="@(v => _addType = Enum.Parse<DietaryRestrictionType>(v))">
+                                @foreach (var t in Enum.GetValues<DietaryRestrictionType>())
+                                {
+                                    <option value="@t">@FormatRestrictionType(t)</option>
+                                }
+                            </FormSelect>
+                        </FormGroup>
+                        <FormGroup Label="Notes" Id="add-dr-notes">
+                            <FormInput Id="add-dr-notes"
+                                       Value="@_addNotes"
+                                       ValueChanged="@(v => _addNotes = v)"
+                                       Placeholder="Additional details" />
+                        </FormGroup>
+                    </div>
+                    @if (!string.IsNullOrEmpty(_formError))
+                    {
+                        <p class="form-error">@_formError</p>
+                    }
+                    <div class="inline-form-actions">
+                        <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="SaveAdd" Disabled="@_isSaving">
+                            @(_isSaving ? "Adding..." : "Add Restriction")
+                        </Button>
+                        <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelAdd">Cancel</Button>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="add-row">
+                    <button class="add-button" @onclick="ShowAddForm">+ Add Restriction</button>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public int ClientId { get; set; }
+    [Parameter] public List<ClientDietaryRestrictionDto>? InitialData { get; set; }
+    [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
+
+    private List<ClientDietaryRestrictionDto> _restrictions = new();
+    private bool _collapsed;
+    private bool _showAddForm;
+    private bool _isSaving;
+    private string? _formError;
+
+    // Add form
+    private DietaryRestrictionType _addType = DietaryRestrictionType.Vegetarian;
+    private string _addNotes = string.Empty;
+
+    // Edit form
+    private int? _editingId;
+    private DietaryRestrictionType _editType;
+    private string _editNotes = string.Empty;
+
+    // Delete
+    private int? _deletingId;
+
+    protected override void OnParametersSet()
+    {
+        if (InitialData is not null)
+            _restrictions = InitialData;
+    }
+
+    private void ToggleCollapsed() => _collapsed = !_collapsed;
+
+    private async Task<string> GetUserIdAsync()
+    {
+        var authState = await AuthState;
+        return authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+    }
+
+    private static string FormatRestrictionType(DietaryRestrictionType type) => type switch
+    {
+        DietaryRestrictionType.GlutenFree => "Gluten-Free",
+        DietaryRestrictionType.DairyFree => "Dairy-Free",
+        DietaryRestrictionType.LowSodium => "Low Sodium",
+        DietaryRestrictionType.NutFree => "Nut-Free",
+        _ => type.ToString()
+    };
+
+    private void ShowAddForm()
+    {
+        _showAddForm = true;
+        _editingId = null;
+        _deletingId = null;
+        _formError = null;
+        _addType = DietaryRestrictionType.Vegetarian;
+        _addNotes = string.Empty;
+    }
+
+    private void CancelAdd() { _showAddForm = false; _formError = null; }
+
+    private async Task SaveAdd()
+    {
+        _isSaving = true;
+        _formError = null;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            var dto = new CreateClientDietaryRestrictionDto(ClientId, _addType, NullIfEmpty(_addNotes));
+            var created = await HealthProfileService.CreateDietaryRestrictionAsync(dto, userId);
+            _restrictions.Add(created);
+            _showAddForm = false;
+        }
+        catch
+        {
+            _formError = "Failed to add restriction. Please try again.";
+        }
+        finally { _isSaving = false; }
+    }
+
+    private void StartEdit(ClientDietaryRestrictionDto r)
+    {
+        _editingId = r.Id;
+        _editType = r.RestrictionType;
+        _editNotes = r.Notes ?? string.Empty;
+        _deletingId = null;
+        _showAddForm = false;
+        _formError = null;
+    }
+
+    private void CancelEdit() { _editingId = null; _formError = null; }
+
+    private async Task SaveEdit()
+    {
+        _isSaving = true;
+        _formError = null;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            var dto = new UpdateClientDietaryRestrictionDto(_editType, NullIfEmpty(_editNotes));
+            var success = await HealthProfileService.UpdateDietaryRestrictionAsync(_editingId!.Value, dto, userId);
+            if (success)
+            {
+                var updated = await HealthProfileService.GetDietaryRestrictionByIdAsync(_editingId.Value);
+                if (updated is not null)
+                {
+                    var idx = _restrictions.FindIndex(r => r.Id == _editingId.Value);
+                    if (idx >= 0) _restrictions[idx] = updated;
+                }
+                _editingId = null;
+            }
+            else { _formError = "Failed to update restriction."; }
+        }
+        catch { _formError = "Failed to update restriction. Please try again."; }
+        finally { _isSaving = false; }
+    }
+
+    private void StartDelete(int id)
+    {
+        _deletingId = id;
+        _editingId = null;
+        _showAddForm = false;
+        _formError = null;
+    }
+
+    private void CancelDelete() => _deletingId = null;
+
+    private async Task ConfirmDelete()
+    {
+        _isSaving = true;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            if (await HealthProfileService.DeleteDietaryRestrictionAsync(_deletingId!.Value, userId))
+            {
+                _restrictions.RemoveAll(r => r.Id == _deletingId.Value);
+                _deletingId = null;
+            }
+        }
+        catch { _formError = "Failed to delete restriction."; }
+        finally { _isSaving = false; }
+    }
+
+    private static string? NullIfEmpty(string value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Nutrir.Web/Components/Widgets/DietaryRestrictionsSection.razor.css
+++ b/src/Nutrir.Web/Components/Widgets/DietaryRestrictionsSection.razor.css
@@ -1,0 +1,209 @@
+/* ── Health Section Card ──────────────────────────────── */
+.health-section {
+    background: var(--color-bg-card);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--color-border);
+    overflow: hidden;
+}
+
+.section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-bg-alt);
+    border-bottom: 1px solid var(--color-border);
+    cursor: pointer;
+    user-select: none;
+}
+
+.section-header-left {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.section-header-label {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+}
+
+.section-count {
+    font-size: var(--text-xs);
+    font-weight: 400;
+    color: var(--color-text-muted);
+}
+
+.section-toggle {
+    background: none;
+    border: none;
+    padding: var(--space-1);
+    cursor: pointer;
+    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+}
+
+.toggle-icon {
+    transition: transform var(--duration-fast) var(--ease-default);
+}
+
+.toggle-icon.collapsed {
+    transform: rotate(-90deg);
+}
+
+/* ── List ─────────────────────────────────────────────── */
+.section-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.section-empty {
+    padding: var(--space-8) var(--space-4);
+    text-align: center;
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+}
+
+.list-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    transition: background var(--duration-fast) var(--ease-default);
+}
+
+.list-row:hover {
+    background: var(--color-bg-alt);
+}
+
+.list-row-primary {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.list-row-title {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.list-row-meta {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+}
+
+.list-row-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+}
+
+.row-action {
+    background: none;
+    border: none;
+    padding: var(--space-1);
+    cursor: pointer;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    transition: color var(--duration-fast) var(--ease-default),
+                background var(--duration-fast) var(--ease-default);
+}
+
+.row-action:hover {
+    color: var(--color-primary);
+    background: var(--color-bg-alt);
+}
+
+.row-action-danger:hover {
+    color: var(--color-error);
+}
+
+/* ── Badge Dot ────────────────────────────────────────── */
+.badge-dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: var(--radius-full);
+    background: currentColor;
+}
+
+/* ── Inline Form ──────────────────────────────────────── */
+.inline-form {
+    padding: var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-bg-alt);
+}
+
+.inline-form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--space-3);
+}
+
+.inline-form-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+}
+
+.form-error {
+    font-size: var(--text-xs);
+    color: var(--color-error);
+    margin: var(--space-2) 0 0;
+}
+
+/* ── Delete Confirm Row ───────────────────────────────── */
+.delete-confirm-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-error) 5%, var(--color-bg-card));
+}
+
+.delete-confirm-text {
+    font-size: var(--text-sm);
+    color: var(--color-text);
+}
+
+.delete-confirm-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+}
+
+/* ── Add Row ──────────────────────────────────────────── */
+.add-row {
+    padding: var(--space-2) var(--space-4);
+}
+
+.add-button {
+    background: none;
+    border: none;
+    padding: var(--space-1) 0;
+    cursor: pointer;
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--color-primary);
+    transition: opacity var(--duration-fast) var(--ease-default);
+}
+
+.add-button:hover {
+    opacity: 0.8;
+}

--- a/src/Nutrir.Web/Components/Widgets/MedicationFormGroup.razor
+++ b/src/Nutrir.Web/Components/Widgets/MedicationFormGroup.razor
@@ -1,0 +1,81 @@
+<div class="health-form-section">
+    <div class="health-form-label">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m10.5 20.5 10-10a4.95 4.95 0 1 0-7-7l-10 10a4.95 4.95 0 1 0 7 7Z"/>
+            <path d="m8.5 8.5 7 7"/>
+        </svg>
+        <span>Medications</span>
+    </div>
+
+    @foreach (var entry in Entries)
+    {
+        var index = Entries.IndexOf(entry);
+        <div class="health-form-entry">
+            <div class="form-grid">
+                <FormGroup Label="Medication Name" Id="@($"med-name-{index}")">
+                    <FormInput Id="@($"med-name-{index}")"
+                               Value="@entry.Name"
+                               ValueChanged="@(v => entry.Name = v)"
+                               Placeholder="e.g. Metformin" />
+                </FormGroup>
+                <FormGroup Label="Dosage" Id="@($"med-dosage-{index}")">
+                    <FormInput Id="@($"med-dosage-{index}")"
+                               Value="@entry.Dosage"
+                               ValueChanged="@(v => entry.Dosage = v)"
+                               Placeholder="e.g. 500mg" />
+                </FormGroup>
+                <FormGroup Label="Frequency" Id="@($"med-freq-{index}")">
+                    <FormInput Id="@($"med-freq-{index}")"
+                               Value="@entry.Frequency"
+                               ValueChanged="@(v => entry.Frequency = v)"
+                               Placeholder="e.g. Twice daily" />
+                </FormGroup>
+                <FormGroup Label="Prescribed For" Id="@($"med-for-{index}")">
+                    <FormInput Id="@($"med-for-{index}")"
+                               Value="@entry.PrescribedFor"
+                               ValueChanged="@(v => entry.PrescribedFor = v)"
+                               Placeholder="e.g. Type 2 Diabetes" />
+                </FormGroup>
+            </div>
+            <button class="health-form-remove" type="button" @onclick="@(() => Remove(index))" title="Remove">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5h10M6.5 7v4M9.5 7v4"/><path d="M4 4.5l.5 8.5a1.5 1.5 0 0 0 1.5 1.5h4a1.5 1.5 0 0 0 1.5-1.5l.5-8.5"/><path d="M6 4.5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1.5"/></svg>
+            </button>
+        </div>
+    }
+
+    <button class="health-form-add" type="button" @onclick="Add">+ Add Medication</button>
+</div>
+
+@code {
+    [Parameter] public List<MedicationEntry> Entries { get; set; } = new();
+
+    private void Add()
+    {
+        Entries.Add(new MedicationEntry());
+    }
+
+    private void Remove(int index)
+    {
+        if (index >= 0 && index < Entries.Count)
+            Entries.RemoveAt(index);
+    }
+
+    public List<(string Name, string? Dosage, string? Frequency, string? PrescribedFor)> GetValidEntries()
+    {
+        return Entries
+            .Where(e => !string.IsNullOrWhiteSpace(e.Name))
+            .Select(e => (e.Name!.Trim(), NullIfEmpty(e.Dosage), NullIfEmpty(e.Frequency), NullIfEmpty(e.PrescribedFor)))
+            .ToList();
+    }
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public class MedicationEntry
+    {
+        public string? Name { get; set; }
+        public string? Dosage { get; set; }
+        public string? Frequency { get; set; }
+        public string? PrescribedFor { get; set; }
+    }
+}

--- a/src/Nutrir.Web/Components/Widgets/MedicationsSection.razor
+++ b/src/Nutrir.Web/Components/Widgets/MedicationsSection.razor
@@ -1,0 +1,358 @@
+@using Nutrir.Core.DTOs
+@using Nutrir.Core.Interfaces
+@using Microsoft.AspNetCore.Components.Authorization
+@using System.Security.Claims
+
+@inject IClientHealthProfileService HealthProfileService
+
+<div class="table-card health-section">
+    <div class="section-header" @onclick="ToggleCollapsed" role="button" tabindex="0">
+        <div class="section-header-left">
+            <span class="section-header-label">Medications</span>
+            <span class="section-count">(@_medications.Count)</span>
+        </div>
+        <button class="section-toggle" aria-label="@(_collapsed ? "Expand" : "Collapse")">
+            <svg class="toggle-icon @(_collapsed ? "collapsed" : "")" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m4 6 4 4 4-4"/>
+            </svg>
+        </button>
+    </div>
+    @if (!_collapsed)
+    {
+        <div class="section-list">
+            @if (_medications.Count == 0 && !_showAddForm)
+            {
+                <div class="section-empty">No medications recorded</div>
+            }
+            else
+            {
+                @foreach (var med in _medications)
+                {
+                    @if (_editingId == med.Id)
+                    {
+                        <div class="inline-form">
+                            <div class="inline-form-grid">
+                                <FormGroup Label="Name" Id="edit-med-name">
+                                    <FormInput Id="edit-med-name"
+                                               Value="@_editName"
+                                               ValueChanged="@(v => _editName = v)"
+                                               Placeholder="Medication name" />
+                                </FormGroup>
+                                <FormGroup Label="Dosage" Id="edit-med-dosage">
+                                    <FormInput Id="edit-med-dosage"
+                                               Value="@_editDosage"
+                                               ValueChanged="@(v => _editDosage = v)"
+                                               Placeholder="e.g. 500mg" />
+                                </FormGroup>
+                                <FormGroup Label="Frequency" Id="edit-med-freq">
+                                    <FormInput Id="edit-med-freq"
+                                               Value="@_editFrequency"
+                                               ValueChanged="@(v => _editFrequency = v)"
+                                               Placeholder="e.g. Twice daily" />
+                                </FormGroup>
+                                <FormGroup Label="Prescribed For" Id="edit-med-for">
+                                    <FormInput Id="edit-med-for"
+                                               Value="@_editPrescribedFor"
+                                               ValueChanged="@(v => _editPrescribedFor = v)"
+                                               Placeholder="e.g. Hypertension" />
+                                </FormGroup>
+                            </div>
+                            @if (!string.IsNullOrEmpty(_formError))
+                            {
+                                <p class="form-error">@_formError</p>
+                            }
+                            <div class="inline-form-actions">
+                                <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="SaveEdit" Disabled="@_isSaving">
+                                    @(_isSaving ? "Saving..." : "Save")
+                                </Button>
+                                <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelEdit">Cancel</Button>
+                            </div>
+                        </div>
+                    }
+                    else if (_deletingId == med.Id)
+                    {
+                        <div class="delete-confirm-row">
+                            <span class="delete-confirm-text">Delete <strong>@med.Name</strong>?</span>
+                            <div class="delete-confirm-actions">
+                                <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="ConfirmDelete" Disabled="@_isSaving">
+                                    @(_isSaving ? "Deleting..." : "Delete")
+                                </Button>
+                                <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelDelete">Cancel</Button>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="list-row">
+                            <div class="list-row-primary">
+                                <span class="list-row-title">@med.Name</span>
+                                <span class="list-row-meta">
+                                    @if (!string.IsNullOrEmpty(med.Dosage))
+                                    {
+                                        @med.Dosage
+                                    }
+                                    @if (!string.IsNullOrEmpty(med.Dosage) && !string.IsNullOrEmpty(med.Frequency))
+                                    {
+                                        <span> · </span>
+                                    }
+                                    @if (!string.IsNullOrEmpty(med.Frequency))
+                                    {
+                                        @med.Frequency
+                                    }
+                                    @if (!string.IsNullOrEmpty(med.PrescribedFor))
+                                    {
+                                        <span> · For @med.PrescribedFor</span>
+                                    }
+                                </span>
+                            </div>
+                            <div class="list-row-actions">
+                                <button class="row-action" title="Edit" @onclick="@(() => StartEdit(med))">
+                                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 2.5a1.77 1.77 0 0 1 2.5 2.5L5.5 13.5l-3.5 1 1-3.5Z"/></svg>
+                                </button>
+                                <button class="row-action row-action-danger" title="Delete" @onclick="@(() => StartDelete(med.Id))">
+                                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5h10M6.5 7v4M9.5 7v4"/><path d="M4 4.5l.5 8.5a1.5 1.5 0 0 0 1.5 1.5h4a1.5 1.5 0 0 0 1.5-1.5l.5-8.5"/><path d="M6 4.5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1.5"/></svg>
+                                </button>
+                            </div>
+                        </div>
+                    }
+                }
+            }
+
+            @if (_showAddForm)
+            {
+                <div class="inline-form">
+                    <div class="inline-form-grid">
+                        <FormGroup Label="Name" Id="add-med-name">
+                            <FormInput Id="add-med-name"
+                                       Value="@_addName"
+                                       ValueChanged="@(v => _addName = v)"
+                                       Placeholder="Medication name" />
+                        </FormGroup>
+                        <FormGroup Label="Dosage" Id="add-med-dosage">
+                            <FormInput Id="add-med-dosage"
+                                       Value="@_addDosage"
+                                       ValueChanged="@(v => _addDosage = v)"
+                                       Placeholder="e.g. 500mg" />
+                        </FormGroup>
+                        <FormGroup Label="Frequency" Id="add-med-freq">
+                            <FormInput Id="add-med-freq"
+                                       Value="@_addFrequency"
+                                       ValueChanged="@(v => _addFrequency = v)"
+                                       Placeholder="e.g. Twice daily" />
+                        </FormGroup>
+                        <FormGroup Label="Prescribed For" Id="add-med-for">
+                            <FormInput Id="add-med-for"
+                                       Value="@_addPrescribedFor"
+                                       ValueChanged="@(v => _addPrescribedFor = v)"
+                                       Placeholder="e.g. Hypertension" />
+                        </FormGroup>
+                    </div>
+                    @if (!string.IsNullOrEmpty(_formError))
+                    {
+                        <p class="form-error">@_formError</p>
+                    }
+                    <div class="inline-form-actions">
+                        <Button Variant="ButtonVariant.Primary" Size="ButtonSize.Small" OnClick="SaveAdd" Disabled="@_isSaving">
+                            @(_isSaving ? "Adding..." : "Add Medication")
+                        </Button>
+                        <Button Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="CancelAdd">Cancel</Button>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="add-row">
+                    <button class="add-button" @onclick="ShowAddForm">+ Add Medication</button>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public int ClientId { get; set; }
+    [Parameter] public List<ClientMedicationDto>? InitialData { get; set; }
+    [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
+
+    private List<ClientMedicationDto> _medications = new();
+    private bool _collapsed;
+    private bool _showAddForm;
+    private bool _isSaving;
+    private string? _formError;
+
+    // Add form state
+    private string _addName = string.Empty;
+    private string _addDosage = string.Empty;
+    private string _addFrequency = string.Empty;
+    private string _addPrescribedFor = string.Empty;
+
+    // Edit form state
+    private int? _editingId;
+    private string _editName = string.Empty;
+    private string _editDosage = string.Empty;
+    private string _editFrequency = string.Empty;
+    private string _editPrescribedFor = string.Empty;
+
+    // Delete state
+    private int? _deletingId;
+
+    protected override void OnParametersSet()
+    {
+        if (InitialData is not null)
+        {
+            _medications = InitialData;
+        }
+    }
+
+    private void ToggleCollapsed() => _collapsed = !_collapsed;
+
+    private async Task<string> GetUserIdAsync()
+    {
+        var authState = await AuthState;
+        return authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+    }
+
+    private void ShowAddForm()
+    {
+        _showAddForm = true;
+        _editingId = null;
+        _deletingId = null;
+        _formError = null;
+        _addName = string.Empty;
+        _addDosage = string.Empty;
+        _addFrequency = string.Empty;
+        _addPrescribedFor = string.Empty;
+    }
+
+    private void CancelAdd()
+    {
+        _showAddForm = false;
+        _formError = null;
+    }
+
+    private async Task SaveAdd()
+    {
+        if (string.IsNullOrWhiteSpace(_addName))
+        {
+            _formError = "Name is required.";
+            return;
+        }
+
+        _isSaving = true;
+        _formError = null;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            var dto = new CreateClientMedicationDto(
+                ClientId, _addName.Trim(),
+                NullIfEmpty(_addDosage), NullIfEmpty(_addFrequency), NullIfEmpty(_addPrescribedFor));
+            var created = await HealthProfileService.CreateMedicationAsync(dto, userId);
+            _medications.Add(created);
+            _showAddForm = false;
+        }
+        catch
+        {
+            _formError = "Failed to add medication. Please try again.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private void StartEdit(ClientMedicationDto med)
+    {
+        _editingId = med.Id;
+        _editName = med.Name;
+        _editDosage = med.Dosage ?? string.Empty;
+        _editFrequency = med.Frequency ?? string.Empty;
+        _editPrescribedFor = med.PrescribedFor ?? string.Empty;
+        _deletingId = null;
+        _showAddForm = false;
+        _formError = null;
+    }
+
+    private void CancelEdit()
+    {
+        _editingId = null;
+        _formError = null;
+    }
+
+    private async Task SaveEdit()
+    {
+        if (string.IsNullOrWhiteSpace(_editName))
+        {
+            _formError = "Name is required.";
+            return;
+        }
+
+        _isSaving = true;
+        _formError = null;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            var dto = new UpdateClientMedicationDto(
+                _editName.Trim(),
+                NullIfEmpty(_editDosage), NullIfEmpty(_editFrequency), NullIfEmpty(_editPrescribedFor));
+            var success = await HealthProfileService.UpdateMedicationAsync(_editingId!.Value, dto, userId);
+            if (success)
+            {
+                var updated = await HealthProfileService.GetMedicationByIdAsync(_editingId.Value);
+                if (updated is not null)
+                {
+                    var idx = _medications.FindIndex(m => m.Id == _editingId.Value);
+                    if (idx >= 0) _medications[idx] = updated;
+                }
+                _editingId = null;
+            }
+            else
+            {
+                _formError = "Failed to update medication.";
+            }
+        }
+        catch
+        {
+            _formError = "Failed to update medication. Please try again.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private void StartDelete(int id)
+    {
+        _deletingId = id;
+        _editingId = null;
+        _showAddForm = false;
+        _formError = null;
+    }
+
+    private void CancelDelete() => _deletingId = null;
+
+    private async Task ConfirmDelete()
+    {
+        _isSaving = true;
+        try
+        {
+            var userId = await GetUserIdAsync();
+            var success = await HealthProfileService.DeleteMedicationAsync(_deletingId!.Value, userId);
+            if (success)
+            {
+                _medications.RemoveAll(m => m.Id == _deletingId.Value);
+                _deletingId = null;
+            }
+        }
+        catch
+        {
+            _formError = "Failed to delete medication.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private static string? NullIfEmpty(string value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Nutrir.Web/Components/Widgets/MedicationsSection.razor.css
+++ b/src/Nutrir.Web/Components/Widgets/MedicationsSection.razor.css
@@ -1,0 +1,209 @@
+/* ── Health Section Card ──────────────────────────────── */
+.health-section {
+    background: var(--color-bg-card);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--color-border);
+    overflow: hidden;
+}
+
+.section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-bg-alt);
+    border-bottom: 1px solid var(--color-border);
+    cursor: pointer;
+    user-select: none;
+}
+
+.section-header-left {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.section-header-label {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+}
+
+.section-count {
+    font-size: var(--text-xs);
+    font-weight: 400;
+    color: var(--color-text-muted);
+}
+
+.section-toggle {
+    background: none;
+    border: none;
+    padding: var(--space-1);
+    cursor: pointer;
+    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+}
+
+.toggle-icon {
+    transition: transform var(--duration-fast) var(--ease-default);
+}
+
+.toggle-icon.collapsed {
+    transform: rotate(-90deg);
+}
+
+/* ── List ─────────────────────────────────────────────── */
+.section-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.section-empty {
+    padding: var(--space-8) var(--space-4);
+    text-align: center;
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+}
+
+.list-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    transition: background var(--duration-fast) var(--ease-default);
+}
+
+.list-row:hover {
+    background: var(--color-bg-alt);
+}
+
+.list-row-primary {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.list-row-title {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.list-row-meta {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+}
+
+.list-row-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+}
+
+.row-action {
+    background: none;
+    border: none;
+    padding: var(--space-1);
+    cursor: pointer;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    transition: color var(--duration-fast) var(--ease-default),
+                background var(--duration-fast) var(--ease-default);
+}
+
+.row-action:hover {
+    color: var(--color-primary);
+    background: var(--color-bg-alt);
+}
+
+.row-action-danger:hover {
+    color: var(--color-error);
+}
+
+/* ── Badge Dot ────────────────────────────────────────── */
+.badge-dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: var(--radius-full);
+    background: currentColor;
+}
+
+/* ── Inline Form ──────────────────────────────────────── */
+.inline-form {
+    padding: var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-bg-alt);
+}
+
+.inline-form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--space-3);
+}
+
+.inline-form-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+}
+
+.form-error {
+    font-size: var(--text-xs);
+    color: var(--color-error);
+    margin: var(--space-2) 0 0;
+}
+
+/* ── Delete Confirm Row ───────────────────────────────── */
+.delete-confirm-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-error) 5%, var(--color-bg-card));
+}
+
+.delete-confirm-text {
+    font-size: var(--text-sm);
+    color: var(--color-text);
+}
+
+.delete-confirm-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+}
+
+/* ── Add Row ──────────────────────────────────────────── */
+.add-row {
+    padding: var(--space-2) var(--space-4);
+}
+
+.add-button {
+    background: none;
+    border: none;
+    padding: var(--space-1) 0;
+    cursor: pointer;
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--color-primary);
+    transition: opacity var(--duration-fast) var(--ease-default);
+}
+
+.add-button:hover {
+    opacity: 0.8;
+}


### PR DESCRIPTION
## Summary
- Add 4 collapsible health profile sections (allergies, medications, conditions, dietary restrictions) to the client detail page with inline CRUD, severity/status badges, and real-time update support
- Add 4 repeatable form group components for managing health profile entries on client create and edit forms
- Wire `IClientHealthProfileService` into detail, create, and edit pages with full save/load logic

## New Components
| Component | Purpose |
|-----------|---------|
| `AllergiesSection` | Detail page — collapsible allergy list with severity badges (Mild/Moderate/Severe) |
| `MedicationsSection` | Detail page — medication list with dosage/frequency detail |
| `ConditionsSection` | Detail page — conditions with status badges (Active/Managed/Resolved) |
| `DietaryRestrictionsSection` | Detail page — dietary restrictions with human-readable type names |
| `AllergyFormGroup` | Create/edit form — repeatable allergy entries |
| `MedicationFormGroup` | Create/edit form — repeatable medication entries |
| `ConditionFormGroup` | Create/edit form — repeatable condition entries |
| `DietaryRestrictionFormGroup` | Create/edit form — repeatable restriction entries |

## Test plan
- [ ] Navigate to a client detail page — verify four collapsible sections render with correct counts
- [ ] Test inline add/edit/delete for each health profile category on the detail page
- [ ] Test collapsing/expanding sections
- [ ] Create a new client with health profile entries — verify they appear on the detail page
- [ ] Edit a client — verify existing health profile data loads into form groups
- [ ] Modify/remove entries on edit form, save, verify changes persist
- [ ] Verify real-time updates refresh health profile sections
- [ ] Check responsive layout at tablet/mobile breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)