### PR TITLE
feat: add health profile AI tools and seed data

### DIFF
--- a/src/Nutrir.Infrastructure/Data/DatabaseSeeder.cs
+++ b/src/Nutrir.Infrastructure/Data/DatabaseSeeder.cs
@@ -215,14 +215,18 @@ public class DatabaseSeeder
         _logger.LogInformation("Seeded {Count} clients", clients.Count);
 
         // Stage 2: Generate child entities (now clients have real IDs) and persist
-        var (appointments, mealPlans, goals, entries) = generator.GenerateChildEntities(ids);
+        var (appointments, mealPlans, goals, entries, allergies, medications, conditions, dietaryRestrictions) = generator.GenerateChildEntities(ids);
         _dbContext.Appointments.AddRange(appointments);
         _dbContext.MealPlans.AddRange(mealPlans);
         _dbContext.ProgressGoals.AddRange(goals);
         _dbContext.ProgressEntries.AddRange(entries);
+        _dbContext.ClientAllergies.AddRange(allergies);
+        _dbContext.ClientMedications.AddRange(medications);
+        _dbContext.ClientConditions.AddRange(conditions);
+        _dbContext.ClientDietaryRestrictions.AddRange(dietaryRestrictions);
         await _dbContext.SaveChangesAsync();
-        _logger.LogInformation("Seeded {AppointmentCount} appointments, {MealPlanCount} meal plans, {GoalCount} goals, {EntryCount} progress entries",
-            appointments.Count, mealPlans.Count, goals.Count, entries.Count);
+        _logger.LogInformation("Seeded {AppointmentCount} appointments, {MealPlanCount} meal plans, {GoalCount} goals, {EntryCount} progress entries, {AllergyCount} allergies, {MedicationCount} medications, {ConditionCount} conditions, {RestrictionCount} dietary restrictions",
+            appointments.Count, mealPlans.Count, goals.Count, entries.Count, allergies.Count, medications.Count, conditions.Count, dietaryRestrictions.Count);
 
         // Stage 3: Generate audit logs (now all entities have real IDs) and persist
         var auditLogs = generator.GenerateAuditLogs(ids);

--- a/src/Nutrir.Infrastructure/Data/Seeding/ClientProfile.cs
+++ b/src/Nutrir.Infrastructure/Data/Seeding/ClientProfile.cs
@@ -10,7 +10,11 @@ public record ClientProfile(
     GoalType[] RelevantGoalTypes,
     MetricType[] RelevantMetrics,
     string[] GoalTitleTemplates,
-    string[] FoodPoolTags)
+    string[] FoodPoolTags,
+    (string Name, AllergySeverity Severity, AllergyType Type)[] AllergyPool,
+    (string Name, string? Dosage, string? Frequency, string? PrescribedFor)[] MedicationPool,
+    (string Name, string? Code, ConditionStatus Status, string? Notes)[] ConditionPool,
+    DietaryRestrictionType[] RestrictionPool)
 {
     public static IReadOnlyList<ClientProfile> All { get; } = new[]
     {
@@ -38,7 +42,23 @@ public record ClientProfile(
                 "Reduce waist circumference by 2 inches",
                 "Reach target weight of 160 lbs"
             ],
-            FoodPoolTags: ["general", "high-protein", "low-calorie"]),
+            FoodPoolTags: ["general", "high-protein", "low-calorie"],
+            AllergyPool:
+            [
+                ("Peanuts", AllergySeverity.Severe, AllergyType.Food),
+                ("Shellfish", AllergySeverity.Moderate, AllergyType.Food),
+            ],
+            MedicationPool:
+            [
+                ("Orlistat", "120 mg", "Three times daily with meals", "Weight management"),
+                ("Metformin", "500 mg", "Twice daily", "Insulin resistance"),
+            ],
+            ConditionPool:
+            [
+                ("Obesity", "E66.0", ConditionStatus.Active, "BMI > 30"),
+                ("Hypertension", "I10", ConditionStatus.Managed, "Controlled with lifestyle modifications"),
+            ],
+            RestrictionPool: []),
 
         new ClientProfile(
             Tag: "diabetes",
@@ -64,7 +84,25 @@ public record ClientProfile(
                 "Reduce A1C by 0.5% over 3 months",
                 "Achieve consistent carb intake of 45g per meal"
             ],
-            FoodPoolTags: ["general", "low-gi", "diabetic-friendly"]),
+            FoodPoolTags: ["general", "low-gi", "diabetic-friendly"],
+            AllergyPool:
+            [
+                ("Peanuts", AllergySeverity.Moderate, AllergyType.Food),
+                ("Penicillin", AllergySeverity.Severe, AllergyType.Drug),
+            ],
+            MedicationPool:
+            [
+                ("Metformin", "1000 mg", "Twice daily", "Type 2 diabetes"),
+                ("Insulin Glargine", "20 units", "Once daily at bedtime", "Type 2 diabetes"),
+                ("Gliclazide", "80 mg", "Once daily", "Type 2 diabetes"),
+            ],
+            ConditionPool:
+            [
+                ("Type 2 Diabetes", "E11", ConditionStatus.Active, "Diagnosed 3 years ago"),
+                ("Hypertension", "I10", ConditionStatus.Managed, null),
+                ("Dyslipidemia", "E78.5", ConditionStatus.Active, "Elevated LDL cholesterol"),
+            ],
+            RestrictionPool: [DietaryRestrictionType.LowSodium]),
 
         new ClientProfile(
             Tag: "sports-nutrition",
@@ -90,7 +128,22 @@ public record ClientProfile(
                 "Optimize race-day fuelling protocol",
                 "Reduce body fat to 12% while maintaining strength"
             ],
-            FoodPoolTags: ["general", "high-protein", "high-carb", "energy-dense"]),
+            FoodPoolTags: ["general", "high-protein", "high-carb", "energy-dense"],
+            AllergyPool:
+            [
+                ("Dairy", AllergySeverity.Moderate, AllergyType.Food),
+                ("Soy", AllergySeverity.Mild, AllergyType.Food),
+            ],
+            MedicationPool:
+            [
+                ("Creatine Monohydrate", "5 g", "Once daily", "Athletic performance"),
+                ("Vitamin D", "2000 IU", "Once daily", "Bone health and recovery"),
+            ],
+            ConditionPool:
+            [
+                ("Exercise-induced asthma", "J45.990", ConditionStatus.Managed, "Uses inhaler before exercise"),
+            ],
+            RestrictionPool: [DietaryRestrictionType.DairyFree]),
 
         new ClientProfile(
             Tag: "prenatal",
@@ -116,7 +169,24 @@ public record ClientProfile(
                 "Meet daily folate and iron targets through diet",
                 "Establish consistent meal pattern of 5-6 small meals"
             ],
-            FoodPoolTags: ["general", "iron-rich", "folate-rich", "prenatal"]),
+            FoodPoolTags: ["general", "iron-rich", "folate-rich", "prenatal"],
+            AllergyPool:
+            [
+                ("Shellfish", AllergySeverity.Mild, AllergyType.Food),
+                ("Dust mites", AllergySeverity.Mild, AllergyType.Environmental),
+            ],
+            MedicationPool:
+            [
+                ("Prenatal Multivitamin", null, "Once daily", "Prenatal nutrition"),
+                ("Iron Supplement", "300 mg ferrous gluconate", "Once daily", "Iron supplementation"),
+                ("Folic Acid", "1 mg", "Once daily", "Neural tube defect prevention"),
+            ],
+            ConditionPool:
+            [
+                ("Gestational diabetes", "O24.4", ConditionStatus.Active, "Monitoring blood glucose"),
+                ("Iron-deficiency anemia", "D50.9", ConditionStatus.Active, "Supplementing with oral iron"),
+            ],
+            RestrictionPool: []),
 
         new ClientProfile(
             Tag: "ibs-fodmap",
@@ -142,7 +212,23 @@ public record ClientProfile(
                 "Identify top 3 trigger foods through reintroduction",
                 "Reduce symptom frequency to fewer than 2 episodes per week"
             ],
-            FoodPoolTags: ["general", "low-fodmap"]),
+            FoodPoolTags: ["general", "low-fodmap"],
+            AllergyPool:
+            [
+                ("Wheat", AllergySeverity.Moderate, AllergyType.Food),
+                ("Lactose", AllergySeverity.Moderate, AllergyType.Food),
+            ],
+            MedicationPool:
+            [
+                ("Probiotics", null, "Once daily", "Gut health"),
+                ("Peppermint Oil Capsules", "200 mg", "Three times daily before meals", "IBS symptom relief"),
+            ],
+            ConditionPool:
+            [
+                ("Irritable bowel syndrome", "K58", ConditionStatus.Active, "FODMAP management protocol"),
+                ("Lactose intolerance", "E73.9", ConditionStatus.Active, null),
+            ],
+            RestrictionPool: [DietaryRestrictionType.GlutenFree, DietaryRestrictionType.DairyFree]),
 
         new ClientProfile(
             Tag: "cardiac-rehab",
@@ -168,7 +254,26 @@ public record ClientProfile(
                 "Maintain sodium intake under 2000 mg daily",
                 "Achieve target LDL cholesterol through dietary changes"
             ],
-            FoodPoolTags: ["general", "low-sodium", "mediterranean"]),
+            FoodPoolTags: ["general", "low-sodium", "mediterranean"],
+            AllergyPool:
+            [
+                ("Aspirin", AllergySeverity.Moderate, AllergyType.Drug),
+                ("Shellfish", AllergySeverity.Mild, AllergyType.Food),
+            ],
+            MedicationPool:
+            [
+                ("Atorvastatin", "40 mg", "Once daily at bedtime", "Dyslipidemia"),
+                ("Metoprolol", "50 mg", "Twice daily", "Heart rate and blood pressure control"),
+                ("Ramipril", "5 mg", "Once daily", "Blood pressure and cardiac remodelling"),
+                ("ASA", "81 mg", "Once daily", "Antiplatelet therapy"),
+            ],
+            ConditionPool:
+            [
+                ("Coronary artery disease", "I25.1", ConditionStatus.Managed, "Post-stent placement"),
+                ("Hypertension", "I10", ConditionStatus.Managed, null),
+                ("Dyslipidemia", "E78.5", ConditionStatus.Active, "Target LDL < 2.0 mmol/L"),
+            ],
+            RestrictionPool: [DietaryRestrictionType.LowSodium]),
 
         new ClientProfile(
             Tag: "general-wellness",
@@ -194,7 +299,19 @@ public record ClientProfile(
                 "Establish a consistent 3-meal-per-day routine",
                 "Reduce ultra-processed food intake by 50%"
             ],
-            FoodPoolTags: ["general", "balanced"]),
+            FoodPoolTags: ["general", "balanced"],
+            AllergyPool:
+            [
+                ("Seasonal pollen", AllergySeverity.Mild, AllergyType.Environmental),
+                ("Dust mites", AllergySeverity.Mild, AllergyType.Environmental),
+            ],
+            MedicationPool:
+            [
+                ("Multivitamin", null, "Once daily", "General nutrition"),
+                ("Vitamin D", "1000 IU", "Once daily", "Bone health"),
+            ],
+            ConditionPool: [],
+            RestrictionPool: []),
 
         new ClientProfile(
             Tag: "post-surgical",
@@ -220,6 +337,23 @@ public record ClientProfile(
                 "Consume 130+ grams of protein daily during recovery",
                 "Transition to full solid diet within 4 weeks post-surgery"
             ],
-            FoodPoolTags: ["general", "high-protein", "anti-inflammatory"]),
+            FoodPoolTags: ["general", "high-protein", "anti-inflammatory"],
+            AllergyPool:
+            [
+                ("Sulfa drugs", AllergySeverity.Severe, AllergyType.Drug),
+                ("Codeine", AllergySeverity.Moderate, AllergyType.Drug),
+            ],
+            MedicationPool:
+            [
+                ("Acetaminophen", "500 mg", "Every 6 hours as needed", "Post-surgical pain management"),
+                ("Iron Supplement", "300 mg ferrous gluconate", "Once daily", "Post-surgical anemia"),
+                ("Collagen Peptides", "10 g", "Once daily", "Wound healing support"),
+            ],
+            ConditionPool:
+            [
+                ("Post-surgical recovery", null, ConditionStatus.Active, "Recovering from abdominal surgery"),
+                ("Iron-deficiency anemia", "D50.9", ConditionStatus.Active, "Secondary to surgical blood loss"),
+            ],
+            RestrictionPool: []),
     };
 }

--- a/src/Nutrir.Infrastructure/Data/Seeding/Generators/HealthProfileGenerator.cs
+++ b/src/Nutrir.Infrastructure/Data/Seeding/Generators/HealthProfileGenerator.cs
@@ -1,0 +1,134 @@
+using Bogus;
+using Nutrir.Core.Entities;
+
+namespace Nutrir.Infrastructure.Data.Seeding.Generators;
+
+public record GeneratedHealthProfile(
+    List<ClientAllergy> Allergies,
+    List<ClientMedication> Medications,
+    List<ClientCondition> Conditions,
+    List<ClientDietaryRestriction> DietaryRestrictions);
+
+public class HealthProfileGenerator
+{
+    private readonly Faker _faker;
+
+    public HealthProfileGenerator(Faker faker)
+    {
+        _faker = faker;
+    }
+
+    public GeneratedHealthProfile Generate(List<GeneratedClient> clients)
+    {
+        var allergies = new List<ClientAllergy>();
+        var medications = new List<ClientMedication>();
+        var conditions = new List<ClientCondition>();
+        var dietaryRestrictions = new List<ClientDietaryRestriction>();
+
+        var eligibleClients = clients
+            .Where(c => c.Client.ConsentGiven && !c.Client.IsDeleted)
+            .ToList();
+
+        foreach (var generated in eligibleClients)
+        {
+            // ~82% of clients get health profile data
+            if (!_faker.Random.Bool(0.82f))
+                continue;
+
+            var client = generated.Client;
+            var profile = generated.Profile;
+            var baseDate = client.CreatedAt.AddDays(_faker.Random.Double(0, 2));
+
+            // Allergies: 0-3 from pool (weighted: 15% get 0, 40% get 1, 30% get 2, 15% get 3)
+            if (profile.AllergyPool.Length > 0)
+            {
+                var allergyCount = PickWeightedCount(profile.AllergyPool.Length, 3, [0.15, 0.40, 0.30, 0.15]);
+                var selectedAllergies = _faker.PickRandom(profile.AllergyPool, allergyCount).Distinct().ToList();
+                foreach (var a in selectedAllergies)
+                {
+                    allergies.Add(new ClientAllergy
+                    {
+                        ClientId = client.Id,
+                        Name = a.Name,
+                        Severity = a.Severity,
+                        AllergyType = a.Type,
+                        CreatedAt = baseDate,
+                    });
+                }
+            }
+
+            // Medications: 1-3 from pool
+            if (profile.MedicationPool.Length > 0)
+            {
+                var medCount = _faker.Random.Int(1, Math.Min(3, profile.MedicationPool.Length));
+                var selectedMeds = _faker.PickRandom(profile.MedicationPool, medCount).Distinct().ToList();
+                foreach (var m in selectedMeds)
+                {
+                    medications.Add(new ClientMedication
+                    {
+                        ClientId = client.Id,
+                        Name = m.Name,
+                        Dosage = m.Dosage,
+                        Frequency = m.Frequency,
+                        PrescribedFor = m.PrescribedFor,
+                        CreatedAt = baseDate,
+                    });
+                }
+            }
+
+            // Conditions: 1-2 from pool
+            if (profile.ConditionPool.Length > 0)
+            {
+                var condCount = _faker.Random.Int(1, Math.Min(2, profile.ConditionPool.Length));
+                var selectedConditions = _faker.PickRandom(profile.ConditionPool, condCount).Distinct().ToList();
+                foreach (var c in selectedConditions)
+                {
+                    conditions.Add(new ClientCondition
+                    {
+                        ClientId = client.Id,
+                        Name = c.Name,
+                        Code = c.Code,
+                        Status = c.Status,
+                        Notes = c.Notes,
+                        DiagnosisDate = _faker.Random.Bool(0.6f)
+                            ? DateOnly.FromDateTime(client.CreatedAt.AddDays(-_faker.Random.Int(30, 730)))
+                            : null,
+                        CreatedAt = baseDate,
+                    });
+                }
+            }
+
+            // Restrictions: 0-2 from pool
+            if (profile.RestrictionPool.Length > 0)
+            {
+                var restCount = _faker.Random.Int(0, Math.Min(2, profile.RestrictionPool.Length));
+                var selectedRestrictions = _faker.PickRandom(profile.RestrictionPool, restCount).Distinct().ToList();
+                foreach (var r in selectedRestrictions)
+                {
+                    dietaryRestrictions.Add(new ClientDietaryRestriction
+                    {
+                        ClientId = client.Id,
+                        RestrictionType = r,
+                        CreatedAt = baseDate,
+                    });
+                }
+            }
+        }
+
+        return new GeneratedHealthProfile(allergies, medications, conditions, dietaryRestrictions);
+    }
+
+    private int PickWeightedCount(int poolSize, int maxCount, double[] weights)
+    {
+        var effectiveMax = Math.Min(maxCount, poolSize);
+        var roll = _faker.Random.Double();
+        var cumulative = 0.0;
+        for (var i = 0; i <= effectiveMax; i++)
+        {
+            cumulative += i < weights.Length ? weights[i] : 0;
+            if (roll < cumulative)
+                return i;
+        }
+        return effectiveMax;
+    }
+}

--- a/src/Nutrir.Infrastructure/Data/Seeding/SeedDataGenerator.cs
+++ b/src/Nutrir.Infrastructure/Data/Seeding/SeedDataGenerator.cs
@@ -39,7 +39,8 @@ public class SeedDataGenerator
     /// <summary>
     /// Stage 2: Generate appointments, meal plans, progress. Clients must already be persisted (have real IDs).
     /// </summary>
-    public (List<Appointment> Appointments, List<MealPlan> MealPlans, List<ProgressGoal> Goals, List<ProgressEntry> Entries)
+    public (List<Appointment> Appointments, List<MealPlan> MealPlans, List<ProgressGoal> Goals, List<ProgressEntry> Entries,
+            List<ClientAllergy> Allergies, List<ClientMedication> Medications, List<ClientCondition> Conditions, List<ClientDietaryRestriction> DietaryRestrictions)
         GenerateChildEntities(string[] nutritionistIds)
     {
         if (_generatedClients is null)
@@ -54,7 +55,11 @@ public class SeedDataGenerator
         var progressGenerator = new ProgressGenerator(_faker);
         var progress = progressGenerator.Generate(_generatedClients, _options.ProgressEntriesPerClient, nutritionistIds);
 
-        return (_appointments, _mealPlans, progress.Goals, progress.Entries);
+        var healthProfileGenerator = new HealthProfileGenerator(_faker);
+        var healthProfile = healthProfileGenerator.Generate(_generatedClients);
+
+        return (_appointments, _mealPlans, progress.Goals, progress.Entries,
+            healthProfile.Allergies, healthProfile.Medications, healthProfile.Conditions, healthProfile.DietaryRestrictions);
     }
 
     /// <summary>

--- a/src/Nutrir.Infrastructure/Services/AiToolExecutor.cs
+++ b/src/Nutrir.Infrastructure/Services/AiToolExecutor.cs
@@ -11,6 +11,7 @@ namespace Nutrir.Infrastructure.Services;
 public class AiToolExecutor
 {
     private readonly IClientService _clientService;
+    private readonly IClientHealthProfileService _healthProfileService;
     private readonly IAppointmentService _appointmentService;
     private readonly IMealPlanService _mealPlanService;
     private readonly IProgressService _progressService;
@@ -48,6 +49,20 @@ public class AiToolExecutor
         ["delete_goal"] = ConfirmationTier.Standard,
         ["create_progress_entry"] = ConfirmationTier.Standard,
         ["delete_progress_entry"] = ConfirmationTier.Standard,
+
+        // Standard tier — Health Profile
+        ["add_client_allergy"] = ConfirmationTier.Standard,
+        ["update_client_allergy"] = ConfirmationTier.Standard,
+        ["remove_client_allergy"] = ConfirmationTier.Standard,
+        ["add_client_medication"] = ConfirmationTier.Standard,
+        ["update_client_medication"] = ConfirmationTier.Standard,
+        ["remove_client_medication"] = ConfirmationTier.Standard,
+        ["add_client_condition"] = ConfirmationTier.Standard,
+        ["update_client_condition"] = ConfirmationTier.Standard,
+        ["remove_client_condition"] = ConfirmationTier.Standard,
+        ["add_client_dietary_restriction"] = ConfirmationTier.Standard,
+        ["update_client_dietary_restriction"] = ConfirmationTier.Standard,
+        ["remove_client_dietary_restriction"] = ConfirmationTier.Standard,
 
         // Elevated tier — user/identity management
         ["create_user"] = ConfirmationTier.Elevated,
@@ -94,6 +109,19 @@ public class AiToolExecutor
 
                 "create_progress_entry" => await BuildCreateProgressEntryContext(input),
                 "delete_progress_entry" => await BuildDeleteProgressEntryContext(input),
+
+                "add_client_allergy" => await BuildHealthProfileAddContext("allergy", input),
+                "update_client_allergy" => BuildHealthProfileMutationContext("update", "allergy", input),
+                "remove_client_allergy" => BuildHealthProfileMutationContext("remove", "allergy", input),
+                "add_client_medication" => await BuildHealthProfileAddContext("medication", input),
+                "update_client_medication" => BuildHealthProfileMutationContext("update", "medication", input),
+                "remove_client_medication" => BuildHealthProfileMutationContext("remove", "medication", input),
+                "add_client_condition" => await BuildHealthProfileAddContext("condition", input),
+                "update_client_condition" => BuildHealthProfileMutationContext("update", "condition", input),
+                "remove_client_condition" => BuildHealthProfileMutationContext("remove", "condition", input),
+                "add_client_dietary_restriction" => await BuildHealthProfileAddContext("dietary restriction", input),
+                "update_client_dietary_restriction" => BuildHealthProfileMutationContext("update", "dietary restriction", input),
+                "remove_client_dietary_restriction" => BuildHealthProfileMutationContext("remove", "dietary restriction", input),
 
                 "create_user" => BuildCreateUserContext(input),
                 "change_user_role" => await BuildUserContext("change_role", input),
@@ -414,6 +442,38 @@ public class AiToolExecutor
         return ($"delete progress entry #{id?.ToString() ?? "?"}", new EntityContext("Progress Entry", "delete", id, $"#{id}", null));
     }
 
+    private async Task<(string Description, EntityContext? Entity)> BuildHealthProfileAddContext(string entityType, JsonElement input)
+    {
+        var clientId = GetOptionalInt(input, "client_id");
+        var clientName = await ResolveClientNameAsync(clientId);
+        var name = GetOptionalString(input, "name") ?? GetOptionalString(input, "restriction_type") ?? "?";
+        var desc = clientName is not null
+            ? $"add {entityType} \"{name}\" for \"{clientName}\" (client #{clientId})"
+            : $"add {entityType} \"{name}\" for client #{clientId?.ToString() ?? "?"}";
+        var fields = BuildFieldChangesFromInput(input, "client_id");
+        var label = FormatFieldLabel(entityType);
+        return (desc, new EntityContext(label, "add", null, name, fields));
+    }
+
+    private static (string Description, EntityContext? Entity) BuildHealthProfileMutationContext(string verb, string entityType, JsonElement input)
+    {
+        var id = GetOptionalInt(input, "id");
+        var name = GetOptionalString(input, "name") ?? GetOptionalString(input, "restriction_type");
+        var label = FormatFieldLabel(entityType);
+        var entityLabel = name is not null
+            ? $"{entityType} \"{name}\" (#{id})"
+            : $"{entityType} #{id?.ToString() ?? "?"}";
+        var desc = $"{verb} client {entityLabel}";
+
+        if (verb == "update")
+        {
+            var fields = BuildFieldChangesFromInput(input, "id");
+            return (desc, new EntityContext(label, verb, id, name ?? $"#{id}", fields));
+        }
+
+        return (desc, new EntityContext(label, verb, id, name ?? $"#{id}", null));
+    }
+
     private static (string Description, EntityContext Entity) BuildCreateUserContext(JsonElement input)
     {
         var firstName = GetOptionalString(input, "first_name") ?? "?";
@@ -542,6 +602,7 @@ public class AiToolExecutor
 
     public AiToolExecutor(
         IClientService clientService,
+        IClientHealthProfileService healthProfileService,
         IAppointmentService appointmentService,
         IMealPlanService mealPlanService,
         IProgressService progressService,
@@ -551,6 +612,7 @@ public class AiToolExecutor
         ILogger<AiToolExecutor> logger)
     {
         _clientService = clientService;
+        _healthProfileService = healthProfileService;
         _appointmentService = appointmentService;
         _mealPlanService = mealPlanService;
         _progressService = progressService;
@@ -606,6 +668,20 @@ public class AiToolExecutor
             // Write tools — Progress Entries
             ["create_progress_entry"] = HandleCreateProgressEntry,
             ["delete_progress_entry"] = HandleDeleteProgressEntry,
+
+            // Write tools — Health Profile
+            ["add_client_allergy"] = HandleAddClientAllergy,
+            ["update_client_allergy"] = HandleUpdateClientAllergy,
+            ["remove_client_allergy"] = HandleRemoveClientAllergy,
+            ["add_client_medication"] = HandleAddClientMedication,
+            ["update_client_medication"] = HandleUpdateClientMedication,
+            ["remove_client_medication"] = HandleRemoveClientMedication,
+            ["add_client_condition"] = HandleAddClientCondition,
+            ["update_client_condition"] = HandleUpdateClientCondition,
+            ["remove_client_condition"] = HandleRemoveClientCondition,
+            ["add_client_dietary_restriction"] = HandleAddClientDietaryRestriction,
+            ["update_client_dietary_restriction"] = HandleUpdateClientDietaryRestriction,
+            ["remove_client_dietary_restriction"] = HandleRemoveClientDietaryRestriction,
 
             // Write tools — User Management
             ["create_user"] = HandleCreateUser,
@@ -975,6 +1051,126 @@ public class AiToolExecutor
                 },
                 "id"),
 
+            // --- Write Tools: Health Profile — Allergies ---
+
+            CreateTool("add_client_allergy", "Add an allergy to a client's health profile.",
+                new Dictionary<string, object>
+                {
+                    ["client_id"] = new { type = "integer", description = "The client ID" },
+                    ["name"] = new { type = "string", description = "Allergy name (e.g. Peanuts, Shellfish, Penicillin)" },
+                    ["severity"] = new { type = "string", description = "Severity level", @enum = new[] { "Mild", "Moderate", "Severe" } },
+                    ["allergy_type"] = new { type = "string", description = "Type of allergy", @enum = new[] { "Food", "Drug", "Environmental", "Other" } },
+                },
+                "client_id", "name", "severity", "allergy_type"),
+
+            CreateTool("update_client_allergy", "Update an existing client allergy.",
+                new Dictionary<string, object>
+                {
+                    ["id"] = new { type = "integer", description = "The allergy ID" },
+                    ["name"] = new { type = "string", description = "Allergy name" },
+                    ["severity"] = new { type = "string", description = "Severity level", @enum = new[] { "Mild", "Moderate", "Severe" } },
+                    ["allergy_type"] = new { type = "string", description = "Type of allergy", @enum = new[] { "Food", "Drug", "Environmental", "Other" } },
+                },
+                "id", "name", "severity", "allergy_type"),
+
+            CreateTool("remove_client_allergy", "Remove an allergy from a client's health profile.",
+                new Dictionary<string, object>
+                {
+                    ["id"] = new { type = "integer", description = "The allergy ID to remove" },
+                },
+                "id"),
+
+            // --- Write Tools: Health Profile — Medications ---
+
+            CreateTool("add_client_medication", "Add a medication to a client's health profile.",
+                new Dictionary<string, object>
+                {
+                    ["client_id"] = new { type = "integer", description = "The client ID" },
+                    ["name"] = new { type = "string", description = "Medication name" },
+                    ["dosage"] = new { type = "string", description = "Dosage (e.g. 500 mg)" },
+                    ["frequency"] = new { type = "string", description = "Frequency (e.g. Twice daily)" },
+                    ["prescribed_for"] = new { type = "string", description = "What the medication is prescribed for" },
+                },
+                "client_id", "name"),
+
+            CreateTool("update_client_medication", "Update an existing client medication.",
+                new Dictionary<string, object>
+                {
+                    ["id"] = new { type = "integer", description = "The medication ID" },
+                    ["name"] = new { type = "string", description = "Medication name" },
+                    ["dosage"] = new { type = "string", description = "Dosage" },
+                    ["frequency"] = new { type = "string", description = "Frequency" },
+                    ["prescribed_for"] = new { type = "string", description = "What the medication is prescribed for" },
+                },
+                "id", "name"),
+
+            CreateTool("remove_client_medication", "Remove a medication from a client's health profile.",
+                new Dictionary<string, object>
+                {
+                    ["id"] = new { type = "integer", description = "The medication ID to remove" },
+                },
+                "id"),
+
+            // --- Write Tools: Health Profile — Conditions ---
+
+            CreateTool("add_client_condition", "Add a medical condition to a client's health profile.",
+                new Dictionary<string, object>
+                {
+                    ["client_id"] = new { type = "integer", description = "The client ID" },
+                    ["name"] = new { type = "string", description = "Condition name" },
+                    ["status"] = new { type = "string", description = "Condition status", @enum = new[] { "Active", "Managed", "Resolved" } },
+                    ["code"] = new { type = "string", description = "ICD code (e.g. E11, I10)" },
+                    ["diagnosis_date"] = new { type = "string", description = "Diagnosis date (yyyy-MM-dd)" },
+                    ["notes"] = new { type = "string", description = "Additional notes about the condition" },
+                },
+                "client_id", "name", "status"),
+
+            CreateTool("update_client_condition", "Update an existing client condition.",
+                new Dictionary<string, object>
+                {
+                    ["id"] = new { type = "integer", description = "The condition ID" },
+                    ["name"] = new { type = "string", description = "Condition name" },
+                    ["status"] = new { type = "string", description = "Condition status", @enum = new[] { "Active", "Managed", "Resolved" } },
+                    ["code"] = new { type = "string", description = "ICD code" },
+                    ["diagnosis_date"] = new { type = "string", description = "Diagnosis date (yyyy-MM-dd)" },
+                    ["notes"] = new { type = "string", description = "Additional notes about the condition" },
+                },
+                "id", "name", "status"),
+
+            CreateTool("remove_client_condition", "Remove a condition from a client's health profile.",
+                new Dictionary<string, object>
+                {
+                    ["id"] = new { type = "integer", description = "The condition ID to remove" },
+                },
+                "id"),
+
+            // --- Write Tools: Health Profile — Dietary Restrictions ---
+
+            CreateTool("add_client_dietary_restriction", "Add a dietary restriction to a client's health profile.",
+                new Dictionary<string, object>
+                {
+                    ["client_id"] = new { type = "integer", description = "The client ID" },
+                    ["restriction_type"] = new { type = "string", description = "Type of dietary restriction", @enum = new[] { "Vegetarian", "Vegan", "GlutenFree", "DairyFree", "Kosher", "Halal", "LowSodium", "Ketogenic", "NutFree", "Other" } },
+                    ["notes"] = new { type = "string", description = "Additional notes about the restriction" },
+                },
+                "client_id", "restriction_type"),
+
+            CreateTool("update_client_dietary_restriction", "Update an existing client dietary restriction.",
+                new Dictionary<string, object>
+                {
+                    ["id"] = new { type = "integer", description = "The dietary restriction ID" },
+                    ["restriction_type"] = new { type = "string", description = "Type of dietary restriction", @enum = new[] { "Vegetarian", "Vegan", "GlutenFree", "DairyFree", "Kosher", "Halal", "LowSodium", "Ketogenic", "NutFree", "Other" } },
+                    ["notes"] = new { type = "string", description = "Additional notes about the restriction" },
+                },
+                "id", "restriction_type"),
+
+            CreateTool("remove_client_dietary_restriction", "Remove a dietary restriction from a client's health profile.",
+                new Dictionary<string, object>
+                {
+                    ["id"] = new { type = "integer", description = "The dietary restriction ID to remove" },
+                },
+                "id"),
+
             // --- Write Tools: User Management ---
 
             CreateTool("create_user", "Create a new user account (nutritionist or admin).",
@@ -1052,9 +1248,11 @@ public class AiToolExecutor
     {
         var id = GetRequiredInt(input, "id");
         var client = await _clientService.GetByIdAsync(id);
-        return client is null
-            ? JsonSerializer.Serialize(new { error = $"Client with ID {id} not found" })
-            : JsonSerializer.Serialize(client, SerializerOptions);
+        if (client is null)
+            return JsonSerializer.Serialize(new { error = $"Client with ID {id} not found" });
+
+        var healthProfile = await _healthProfileService.GetHealthProfileSummaryAsync(id);
+        return JsonSerializer.Serialize(new { client, health_profile = healthProfile }, SerializerOptions);
     }
 
     private async Task<string> HandleListAppointments(JsonElement input)
@@ -1484,6 +1682,154 @@ public class AiToolExecutor
         return success
             ? JsonSerializer.Serialize(new { success = true, message = $"Progress entry #{id} deleted" })
             : JsonSerializer.Serialize(new { error = $"Progress entry #{id} not found or delete failed" });
+    }
+
+    // =====================================================
+    // Write Tool Handlers — Health Profile
+    // =====================================================
+
+    private async Task<string> HandleAddClientAllergy(JsonElement input)
+    {
+        var dto = new CreateClientAllergyDto(
+            ClientId: GetRequiredInt(input, "client_id"),
+            Name: GetRequiredString(input, "name"),
+            Severity: GetRequiredEnum<AllergySeverity>(input, "severity"),
+            AllergyType: GetRequiredEnum<AllergyType>(input, "allergy_type"));
+
+        var result = await _healthProfileService.CreateAllergyAsync(dto, _currentUserId ?? "system");
+        return JsonSerializer.Serialize(new { success = true, allergy = result }, SerializerOptions);
+    }
+
+    private async Task<string> HandleUpdateClientAllergy(JsonElement input)
+    {
+        var id = GetRequiredInt(input, "id");
+        var dto = new UpdateClientAllergyDto(
+            Name: GetRequiredString(input, "name"),
+            Severity: GetRequiredEnum<AllergySeverity>(input, "severity"),
+            AllergyType: GetRequiredEnum<AllergyType>(input, "allergy_type"));
+
+        var success = await _healthProfileService.UpdateAllergyAsync(id, dto, _currentUserId ?? "system");
+        return success
+            ? JsonSerializer.Serialize(new { success = true, message = $"Allergy #{id} updated" })
+            : JsonSerializer.Serialize(new { error = $"Allergy #{id} not found or update failed" });
+    }
+
+    private async Task<string> HandleRemoveClientAllergy(JsonElement input)
+    {
+        var id = GetRequiredInt(input, "id");
+        var success = await _healthProfileService.DeleteAllergyAsync(id, _currentUserId ?? "system");
+        return success
+            ? JsonSerializer.Serialize(new { success = true, message = $"Allergy #{id} removed" })
+            : JsonSerializer.Serialize(new { error = $"Allergy #{id} not found or removal failed" });
+    }
+
+    private async Task<string> HandleAddClientMedication(JsonElement input)
+    {
+        var dto = new CreateClientMedicationDto(
+            ClientId: GetRequiredInt(input, "client_id"),
+            Name: GetRequiredString(input, "name"),
+            Dosage: GetOptionalString(input, "dosage"),
+            Frequency: GetOptionalString(input, "frequency"),
+            PrescribedFor: GetOptionalString(input, "prescribed_for"));
+
+        var result = await _healthProfileService.CreateMedicationAsync(dto, _currentUserId ?? "system");
+        return JsonSerializer.Serialize(new { success = true, medication = result }, SerializerOptions);
+    }
+
+    private async Task<string> HandleUpdateClientMedication(JsonElement input)
+    {
+        var id = GetRequiredInt(input, "id");
+        var dto = new UpdateClientMedicationDto(
+            Name: GetRequiredString(input, "name"),
+            Dosage: GetOptionalString(input, "dosage"),
+            Frequency: GetOptionalString(input, "frequency"),
+            PrescribedFor: GetOptionalString(input, "prescribed_for"));
+
+        var success = await _healthProfileService.UpdateMedicationAsync(id, dto, _currentUserId ?? "system");
+        return success
+            ? JsonSerializer.Serialize(new { success = true, message = $"Medication #{id} updated" })
+            : JsonSerializer.Serialize(new { error = $"Medication #{id} not found or update failed" });
+    }
+
+    private async Task<string> HandleRemoveClientMedication(JsonElement input)
+    {
+        var id = GetRequiredInt(input, "id");
+        var success = await _healthProfileService.DeleteMedicationAsync(id, _currentUserId ?? "system");
+        return success
+            ? JsonSerializer.Serialize(new { success = true, message = $"Medication #{id} removed" })
+            : JsonSerializer.Serialize(new { error = $"Medication #{id} not found or removal failed" });
+    }
+
+    private async Task<string> HandleAddClientCondition(JsonElement input)
+    {
+        var dto = new CreateClientConditionDto(
+            ClientId: GetRequiredInt(input, "client_id"),
+            Name: GetRequiredString(input, "name"),
+            Code: GetOptionalString(input, "code"),
+            DiagnosisDate: GetOptionalDateOnly(input, "diagnosis_date"),
+            Status: GetRequiredEnum<ConditionStatus>(input, "status"),
+            Notes: GetOptionalString(input, "notes"));
+
+        var result = await _healthProfileService.CreateConditionAsync(dto, _currentUserId ?? "system");
+        return JsonSerializer.Serialize(new { success = true, condition = result }, SerializerOptions);
+    }
+
+    private async Task<string> HandleUpdateClientCondition(JsonElement input)
+    {
+        var id = GetRequiredInt(input, "id");
+        var dto = new UpdateClientConditionDto(
+            Name: GetRequiredString(input, "name"),
+            Code: GetOptionalString(input, "code"),
+            DiagnosisDate: GetOptionalDateOnly(input, "diagnosis_date"),
+            Status: GetRequiredEnum<ConditionStatus>(input, "status"),
+            Notes: GetOptionalString(input, "notes"));
+
+        var success = await _healthProfileService.UpdateConditionAsync(id, dto, _currentUserId ?? "system");
+        return success
+            ? JsonSerializer.Serialize(new { success = true, message = $"Condition #{id} updated" })
+            : JsonSerializer.Serialize(new { error = $"Condition #{id} not found or update failed" });
+    }
+
+    private async Task<string> HandleRemoveClientCondition(JsonElement input)
+    {
+        var id = GetRequiredInt(input, "id");
+        var success = await _healthProfileService.DeleteConditionAsync(id, _currentUserId ?? "system");
+        return success
+            ? JsonSerializer.Serialize(new { success = true, message = $"Condition #{id} removed" })
+            : JsonSerializer.Serialize(new { error = $"Condition #{id} not found or removal failed" });
+    }
+
+    private async Task<string> HandleAddClientDietaryRestriction(JsonElement input)
+    {
+        var dto = new CreateClientDietaryRestrictionDto(
+            ClientId: GetRequiredInt(input, "client_id"),
+            RestrictionType: GetRequiredEnum<DietaryRestrictionType>(input, "restriction_type"),
+            Notes: GetOptionalString(input, "notes"));
+
+        var result = await _healthProfileService.CreateDietaryRestrictionAsync(dto, _currentUserId ?? "system");
+        return JsonSerializer.Serialize(new { success = true, dietary_restriction = result }, SerializerOptions);
+    }
+
+    private async Task<string> HandleUpdateClientDietaryRestriction(JsonElement input)
+    {
+        var id = GetRequiredInt(input, "id");
+        var dto = new UpdateClientDietaryRestrictionDto(
+            RestrictionType: GetRequiredEnum<DietaryRestrictionType>(input, "restriction_type"),
+            Notes: GetOptionalString(input, "notes"));
+
+        var success = await _healthProfileService.UpdateDietaryRestrictionAsync(id, dto, _currentUserId ?? "system");
+        return success
+            ? JsonSerializer.Serialize(new { success = true, message = $"Dietary restriction #{id} updated" })
+            : JsonSerializer.Serialize(new { error = $"Dietary restriction #{id} not found or update failed" });
+    }
+
+    private async Task<string> HandleRemoveClientDietaryRestriction(JsonElement input)
+    {
+        var id = GetRequiredInt(input, "id");
+        var success = await _healthProfileService.DeleteDietaryRestrictionAsync(id, _currentUserId ?? "system");
+        return success
+            ? JsonSerializer.Serialize(new { success = true, message = $"Dietary restriction #{id} removed" })
+            : JsonSerializer.Serialize(new { error = $"Dietary restriction #{id} not found or removal failed" });
     }
 
     // =====================================================


### PR DESCRIPTION
## Summary
- Add 12 AI assistant tools for managing client health profile entries (add/update/remove for allergies, medications, conditions, dietary restrictions) with Standard confirmation tier and descriptive confirmation messages
- Extend `get_client` tool to return health profile summary alongside client data so the AI sees allergies, medications, conditions, and dietary restrictions
- Add clinically plausible seed data for health profiles across all 8 client archetypes (~82% of eligible clients get health profile data)
- Create `HealthProfileGenerator` and integrate into the existing seed data pipeline

## Test plan
- [ ] `dotnet build` passes with 0 errors and 0 warnings
- [ ] Drop and re-seed database, verify health profile data appears on client detail pages
- [ ] AI assistant `get_client` returns `health_profile` section with allergies, medications, conditions, dietary restrictions
- [ ] AI assistant can add/update/remove health profile entries with confirmation dialogs
- [ ] Check Seq logs for audit entries from health profile mutations

🤖 Generated with [Claude Code](https://claude.com/claude-code)