### PR TITLE
feat: meal plan PDF export

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,12 @@ Organized by domain. Each folder contains specs, designs, and decisions for that
 |----------|-------------|
 | [Health Profile](clients/health-profile.md) | Client health profile data model — allergies, medications, conditions, dietary restrictions (ERD, enums, design decisions) |
 
+## Meal Plans Documents
+
+| Document | Description |
+|----------|-------------|
+| [PDF Export Layout](meal-plans/pdf-export-layout.md) | PDF export layout spec — page setup, header/content/footer structure, color palette, table columns |
+
 ## Compliance Documents
 
 | Document | Description |

--- a/docs/meal-plans/pdf-export-layout.md
+++ b/docs/meal-plans/pdf-export-layout.md
@@ -1,0 +1,89 @@
+# Meal Plan PDF Export — Layout Spec
+
+## Overview
+
+Generates a PDF document from a `MealPlanDetailDto`, providing a printable or shareable version of a meal plan with full nutritional information.
+
+## Page Setup
+
+| Property | Value |
+|----------|-------|
+| Page size | US Letter (8.5 × 11 in) |
+| Horizontal margin | 60 pt |
+| Vertical margin | 50 pt |
+| Base font size | 10 pt |
+| Font | System default (QuestPDF) |
+
+## Color Palette
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| Primary | `#2d6a4f` | Brand text, section headings, header border |
+| Text | `#2a2d2b` | Body text |
+| Muted | `#636865` | Labels, footer text |
+| Day accent | `#e8f5e9` | Day header background |
+
+## Header
+
+- **Top row** — left: "Nutrir" (18 pt, bold, primary); right: plan title (14 pt, bold, text color)
+- **Bottom border** — 2 pt line in primary color
+- **Metadata rows** (below border, 10 pt):
+  - Row 1: "Client: {FirstName} {LastName}" (left) | "Date: {StartDate} — {EndDate}" (right)
+  - Row 2: "Practitioner: {CreatedByName}" (left) | "Status: {Status}" (right)
+- **Macro targets row** (conditional — only if any target is set):
+  - "{CalorieTarget} kcal | {ProteinTargetG}g P | {CarbsTargetG}g C | {FatTargetG}g F"
+  - Muted color, centered
+
+## Content
+
+### Optional Text Sections
+
+Rendered in order if non-empty. Each has a heading (11 pt, bold, primary) and body (10 pt, 1.4× line height):
+
+1. **Description**
+2. **Client Instructions**
+3. **Internal Notes**
+
+### Day Panels
+
+For each day in `Days`, ordered by `DayNumber`:
+
+#### Day Header Row
+- Background: day accent color (`#e8f5e9`)
+- Left: day label (bold) — `Label ?? "Day {DayNumber}"`
+- Right: day-level macro totals — "{TotalCalories} kcal · {TotalProtein}g P · {TotalCarbs}g C · {TotalFat}g F"
+
+#### Meal Slots
+
+For each slot in the day, ordered by `SortOrder`:
+
+- **Slot header**: slot name (bold, 10 pt) — `CustomName ?? MealType.ToString()`
+- **Slot totals** (muted, right-aligned): same macro format as day totals
+
+#### Item Table
+
+QuestPDF `Table` component with columns:
+
+| Column | Width | Alignment |
+|--------|-------|-----------|
+| Food | Relative (flex) | Left |
+| Qty | 60 pt | Right |
+| Cal | 45 pt | Right |
+| P | 40 pt | Right |
+| C | 40 pt | Right |
+| F | 40 pt | Right |
+
+- Header row: bold, muted color
+- Data rows: alternating white / light gray (`#f9f9f9`)
+- Food cell includes item notes in muted italic below the name (if present)
+- Slot total row at bottom of each table: bold values
+
+## Footer
+
+- **Top border** — 1 pt line in `#e0e0e0`
+- Left: "Nutrir — Meal Plan" (8 pt, muted)
+- Right: "Page N of M" (8 pt, muted)
+
+## Page Break Behavior
+
+QuestPDF handles page breaks natively within Table components. Day panels use `EnsureSpace(72)` to avoid orphaned headers at page bottom.

--- a/src/Nutrir.Core/Interfaces/IMealPlanPdfService.cs
+++ b/src/Nutrir.Core/Interfaces/IMealPlanPdfService.cs
@@ -1,0 +1,6 @@
+namespace Nutrir.Core.Interfaces;
+
+public interface IMealPlanPdfService
+{
+    Task<byte[]> GeneratePdfAsync(int mealPlanId, string userId);
+}

--- a/src/Nutrir.Infrastructure/DependencyInjection.cs
+++ b/src/Nutrir.Infrastructure/DependencyInjection.cs
@@ -33,6 +33,7 @@ public static class DependencyInjection
         services.AddScoped<IDashboardService, DashboardService>();
         services.AddScoped<IAppointmentService, AppointmentService>();
         services.AddScoped<IMealPlanService, MealPlanService>();
+        services.AddScoped<IMealPlanPdfService, MealPlanPdfService>();
         services.AddScoped<IProgressService, ProgressService>();
         services.AddScoped<ISearchService, SearchService>();
         services.AddScoped<ITimeZoneService, TimeZoneService>();

--- a/src/Nutrir.Infrastructure/Services/AiToolExecutor.cs
+++ b/src/Nutrir.Infrastructure/Services/AiToolExecutor.cs
@@ -630,6 +630,7 @@ public class AiToolExecutor
             ["get_appointment"] = HandleGetAppointment,
             ["list_meal_plans"] = HandleListMealPlans,
             ["get_meal_plan"] = HandleGetMealPlan,
+            ["export_meal_plan_pdf"] = HandleExportMealPlanPdf,
             ["list_goals"] = HandleListGoals,
             ["get_goal"] = HandleGetGoal,
             ["list_progress"] = HandleListProgress,
@@ -758,6 +759,13 @@ public class AiToolExecutor
                 }),
 
             CreateTool("get_meal_plan", "Get detailed information about a specific meal plan including all days, slots, and items.",
+                new Dictionary<string, object>
+                {
+                    ["id"] = new { type = "integer", description = "The meal plan ID" }
+                },
+                "id"),
+
+            CreateTool("export_meal_plan_pdf", "Generate a PDF export download link for a meal plan. Returns a URL the user can click to download the PDF.",
                 new Dictionary<string, object>
                 {
                     ["id"] = new { type = "integer", description = "The meal plan ID" }
@@ -1580,6 +1588,20 @@ public class AiToolExecutor
         return success
             ? JsonSerializer.Serialize(new { success = true, message = $"Meal plan #{id} deleted" })
             : JsonSerializer.Serialize(new { error = $"Meal plan #{id} not found or delete failed" });
+    }
+
+    private async Task<string> HandleExportMealPlanPdf(JsonElement input)
+    {
+        var id = GetRequiredInt(input, "id");
+        var plan = await _mealPlanService.GetByIdAsync(id);
+        if (plan is null)
+            return JsonSerializer.Serialize(new { error = $"Meal plan #{id} not found" });
+
+        return JsonSerializer.Serialize(new
+        {
+            download_url = $"/api/meal-plans/{id}/pdf",
+            message = $"PDF export ready for '{plan.Title}'. Click the link to download."
+        });
     }
 
     // =====================================================

--- a/src/Nutrir.Infrastructure/Services/MealPlanPdfRenderer.cs
+++ b/src/Nutrir.Infrastructure/Services/MealPlanPdfRenderer.cs
@@ -1,0 +1,270 @@
+using Nutrir.Core.DTOs;
+using Nutrir.Core.Enums;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace Nutrir.Infrastructure.Services;
+
+public static class MealPlanPdfRenderer
+{
+    private const string PrimaryColor = "#2d6a4f";
+    private const string TextColor = "#2a2d2b";
+    private const string MutedColor = "#636865";
+    private const string DayAccentColor = "#e8f5e9";
+    private const string AlternateRowColor = "#f9f9f9";
+
+    public static byte[] Render(MealPlanDetailDto plan)
+    {
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.Letter);
+                page.MarginHorizontal(60);
+                page.MarginVertical(50);
+                page.DefaultTextStyle(x => x.FontSize(10).FontColor(TextColor));
+
+                page.Header().Element(c => ComposeHeader(c, plan));
+                page.Content().Element(c => ComposeContent(c, plan));
+                page.Footer().Element(c => ComposeFooter(c));
+            });
+        });
+
+        return document.GeneratePdf();
+    }
+
+    private static void ComposeHeader(IContainer container, MealPlanDetailDto plan)
+    {
+        container.Column(column =>
+        {
+            column.Item().BorderBottom(2).BorderColor(PrimaryColor).PaddingBottom(10).Row(row =>
+            {
+                row.RelativeItem().Text("Nutrir")
+                    .FontSize(18).Bold().FontColor(PrimaryColor);
+                row.RelativeItem().AlignRight().Text(plan.Title)
+                    .FontSize(14).Bold();
+            });
+
+            column.Item().PaddingTop(12).Row(row =>
+            {
+                row.RelativeItem().Text(text =>
+                {
+                    text.Span("Client: ").Bold();
+                    text.Span($"{plan.ClientFirstName} {plan.ClientLastName}");
+                });
+                row.RelativeItem().AlignRight().Text(text =>
+                {
+                    text.Span("Date: ").Bold();
+                    text.Span(FormatDateRange(plan.StartDate, plan.EndDate));
+                });
+            });
+
+            column.Item().PaddingBottom(8).Row(row =>
+            {
+                row.RelativeItem().Text(text =>
+                {
+                    text.Span("Practitioner: ").Bold();
+                    text.Span(plan.CreatedByName ?? "—");
+                });
+                row.RelativeItem().AlignRight().Text(text =>
+                {
+                    text.Span("Status: ").Bold();
+                    text.Span(plan.Status.ToString());
+                });
+            });
+
+            if (plan.CalorieTarget.HasValue || plan.ProteinTargetG.HasValue ||
+                plan.CarbsTargetG.HasValue || plan.FatTargetG.HasValue)
+            {
+                var parts = new List<string>();
+                if (plan.CalorieTarget.HasValue) parts.Add($"{plan.CalorieTarget.Value:N0} kcal");
+                if (plan.ProteinTargetG.HasValue) parts.Add($"{plan.ProteinTargetG.Value:N0}g P");
+                if (plan.CarbsTargetG.HasValue) parts.Add($"{plan.CarbsTargetG.Value:N0}g C");
+                if (plan.FatTargetG.HasValue) parts.Add($"{plan.FatTargetG.Value:N0}g F");
+                column.Item().PaddingBottom(4).AlignCenter()
+                    .Text($"Targets: {string.Join(" | ", parts)}")
+                    .FontSize(10).FontColor(MutedColor);
+            }
+        });
+    }
+
+    private static void ComposeContent(IContainer container, MealPlanDetailDto plan)
+    {
+        container.PaddingTop(8).Column(column =>
+        {
+            // Optional text sections
+            if (!string.IsNullOrEmpty(plan.Description))
+            {
+                ComposeTextSection(column, "Description", plan.Description);
+            }
+
+            if (!string.IsNullOrEmpty(plan.Instructions))
+            {
+                ComposeTextSection(column, "Client Instructions", plan.Instructions);
+            }
+
+            if (!string.IsNullOrEmpty(plan.Notes))
+            {
+                ComposeTextSection(column, "Internal Notes", plan.Notes);
+            }
+
+            // Day panels
+            foreach (var day in plan.Days)
+            {
+                column.Item().EnsureSpace(72).Column(dayColumn =>
+                {
+                    // Day header
+                    dayColumn.Item().PaddingTop(12).Background(DayAccentColor).Padding(8).Row(row =>
+                    {
+                        row.RelativeItem().Text(day.Label ?? $"Day {day.DayNumber}")
+                            .Bold().FontSize(11);
+                        row.RelativeItem().AlignRight().Text(
+                            $"{day.TotalCalories:N0} kcal \u00b7 {day.TotalProtein:N0}g P \u00b7 {day.TotalCarbs:N0}g C \u00b7 {day.TotalFat:N0}g F")
+                            .FontSize(9).FontColor(MutedColor);
+                    });
+
+                    if (day.MealSlots.Count == 0)
+                    {
+                        dayColumn.Item().Padding(8).Text("No meals added for this day")
+                            .FontSize(9).Italic().FontColor(MutedColor);
+                    }
+                    else
+                    {
+                        foreach (var slot in day.MealSlots)
+                        {
+                            ComposeSlot(dayColumn, slot);
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    private static void ComposeTextSection(ColumnDescriptor column, string heading, string body)
+    {
+        column.Item().PaddingTop(10).Text(heading)
+            .FontSize(11).Bold().FontColor(PrimaryColor);
+        column.Item().PaddingTop(4).Text(body)
+            .FontSize(10).LineHeight(1.4f);
+    }
+
+    private static void ComposeSlot(ColumnDescriptor dayColumn, MealSlotDto slot)
+    {
+        dayColumn.Item().PaddingTop(8).PaddingHorizontal(8).Column(slotColumn =>
+        {
+            // Slot header
+            slotColumn.Item().Row(row =>
+            {
+                row.RelativeItem().Text(slot.CustomName ?? FormatMealType(slot.MealType))
+                    .Bold().FontSize(10);
+                row.RelativeItem().AlignRight().Text(
+                    $"{slot.TotalCalories:N0} kcal \u00b7 {slot.TotalProtein:N0}g P \u00b7 {slot.TotalCarbs:N0}g C \u00b7 {slot.TotalFat:N0}g F")
+                    .FontSize(9).FontColor(MutedColor);
+            });
+
+            if (slot.Items.Count == 0)
+                return;
+
+            // Item table
+            slotColumn.Item().PaddingTop(4).Table(table =>
+            {
+                table.ColumnsDefinition(columns =>
+                {
+                    columns.RelativeColumn(); // Food
+                    columns.ConstantColumn(60); // Qty
+                    columns.ConstantColumn(45); // Cal
+                    columns.ConstantColumn(40); // P
+                    columns.ConstantColumn(40); // C
+                    columns.ConstantColumn(40); // F
+                });
+
+                // Header row
+                table.Header(header =>
+                {
+                    header.Cell().PaddingVertical(4).Text("Food").Bold().FontSize(9).FontColor(MutedColor);
+                    header.Cell().PaddingVertical(4).AlignRight().Text("Qty").Bold().FontSize(9).FontColor(MutedColor);
+                    header.Cell().PaddingVertical(4).AlignRight().Text("Cal").Bold().FontSize(9).FontColor(MutedColor);
+                    header.Cell().PaddingVertical(4).AlignRight().Text("P").Bold().FontSize(9).FontColor(MutedColor);
+                    header.Cell().PaddingVertical(4).AlignRight().Text("C").Bold().FontSize(9).FontColor(MutedColor);
+                    header.Cell().PaddingVertical(4).AlignRight().Text("F").Bold().FontSize(9).FontColor(MutedColor);
+                });
+
+                // Data rows
+                for (var i = 0; i < slot.Items.Count; i++)
+                {
+                    var item = slot.Items[i];
+                    var bgColor = i % 2 == 1 ? AlternateRowColor : "#ffffff";
+
+                    table.Cell().Background(bgColor).PaddingVertical(3).Column(foodCol =>
+                    {
+                        foodCol.Item().Text(item.FoodName).FontSize(10);
+                        if (!string.IsNullOrEmpty(item.Notes))
+                        {
+                            foodCol.Item().Text(item.Notes).FontSize(8).Italic().FontColor(MutedColor);
+                        }
+                    });
+                    table.Cell().Background(bgColor).PaddingVertical(3).AlignRight()
+                        .Text($"{item.Quantity:G} {item.Unit}").FontSize(10);
+                    table.Cell().Background(bgColor).PaddingVertical(3).AlignRight()
+                        .Text($"{item.CaloriesKcal:N0}").FontSize(10);
+                    table.Cell().Background(bgColor).PaddingVertical(3).AlignRight()
+                        .Text($"{item.ProteinG:N0}").FontSize(10);
+                    table.Cell().Background(bgColor).PaddingVertical(3).AlignRight()
+                        .Text($"{item.CarbsG:N0}").FontSize(10);
+                    table.Cell().Background(bgColor).PaddingVertical(3).AlignRight()
+                        .Text($"{item.FatG:N0}").FontSize(10);
+                }
+
+                // Slot total row
+                table.Cell().BorderTop(1).BorderColor("#e0e0e0").PaddingVertical(3)
+                    .Text("Total").Bold().FontSize(9);
+                table.Cell().BorderTop(1).BorderColor("#e0e0e0").PaddingVertical(3)
+                    .AlignRight().Text("").FontSize(9);
+                table.Cell().BorderTop(1).BorderColor("#e0e0e0").PaddingVertical(3)
+                    .AlignRight().Text($"{slot.TotalCalories:N0}").Bold().FontSize(9);
+                table.Cell().BorderTop(1).BorderColor("#e0e0e0").PaddingVertical(3)
+                    .AlignRight().Text($"{slot.TotalProtein:N0}").Bold().FontSize(9);
+                table.Cell().BorderTop(1).BorderColor("#e0e0e0").PaddingVertical(3)
+                    .AlignRight().Text($"{slot.TotalCarbs:N0}").Bold().FontSize(9);
+                table.Cell().BorderTop(1).BorderColor("#e0e0e0").PaddingVertical(3)
+                    .AlignRight().Text($"{slot.TotalFat:N0}").Bold().FontSize(9);
+            });
+        });
+    }
+
+    private static void ComposeFooter(IContainer container)
+    {
+        container.BorderTop(1).BorderColor("#e0e0e0").PaddingTop(6).Row(row =>
+        {
+            row.RelativeItem().Text("Nutrir \u2014 Meal Plan")
+                .FontSize(8).FontColor(MutedColor);
+            row.RelativeItem().AlignRight().Text(text =>
+            {
+                text.Span("Page ").FontSize(8).FontColor(MutedColor);
+                text.CurrentPageNumber().FontSize(8).FontColor(MutedColor);
+                text.Span(" of ").FontSize(8).FontColor(MutedColor);
+                text.TotalPages().FontSize(8).FontColor(MutedColor);
+            });
+        });
+    }
+
+    private static string FormatDateRange(DateOnly? start, DateOnly? end)
+    {
+        if (!start.HasValue && !end.HasValue) return "—";
+        var s = start?.ToString("MMM d, yyyy") ?? "—";
+        var e = end?.ToString("MMM d, yyyy") ?? "—";
+        return $"{s} — {e}";
+    }
+
+    private static string FormatMealType(MealType type) => type switch
+    {
+        MealType.Breakfast => "Breakfast",
+        MealType.MorningSnack => "Morning Snack",
+        MealType.Lunch => "Lunch",
+        MealType.AfternoonSnack => "Afternoon Snack",
+        MealType.Dinner => "Dinner",
+        MealType.EveningSnack => "Evening Snack",
+        _ => type.ToString()
+    };
+}

--- a/src/Nutrir.Infrastructure/Services/MealPlanPdfService.cs
+++ b/src/Nutrir.Infrastructure/Services/MealPlanPdfService.cs
@@ -1,0 +1,33 @@
+using Nutrir.Core.Interfaces;
+
+namespace Nutrir.Infrastructure.Services;
+
+public class MealPlanPdfService : IMealPlanPdfService
+{
+    private readonly IMealPlanService _mealPlanService;
+    private readonly IAuditLogService _auditLogService;
+
+    public MealPlanPdfService(IMealPlanService mealPlanService, IAuditLogService auditLogService)
+    {
+        _mealPlanService = mealPlanService;
+        _auditLogService = auditLogService;
+    }
+
+    public async Task<byte[]> GeneratePdfAsync(int mealPlanId, string userId)
+    {
+        var plan = await _mealPlanService.GetByIdAsync(mealPlanId);
+        if (plan is null)
+            throw new KeyNotFoundException($"Meal plan #{mealPlanId} not found.");
+
+        var pdfBytes = MealPlanPdfRenderer.Render(plan);
+
+        await _auditLogService.LogAsync(
+            userId,
+            "MealPlanPdfExported",
+            "MealPlan",
+            mealPlanId.ToString(),
+            $"Exported PDF for meal plan '{plan.Title}'");
+
+        return pdfBytes;
+    }
+}

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor
@@ -97,6 +97,7 @@
                         <Button Variant="ButtonVariant.Primary" OnClick="NavigateToEditDetails">Edit Details</Button>
                         <Button Variant="ButtonVariant.Outline" OnClick="NavigateToEdit">Edit Meals</Button>
                         <Button Variant="ButtonVariant.Outline" OnClick="ActivatePlan">Activate</Button>
+                        <a href="/api/meal-plans/@_plan.Id/pdf" target="_blank" class="btn btn-outline" download>Export PDF</a>
                         <Button Variant="ButtonVariant.Ghost" OnClick="@(() => _showDeleteConfirm = true)">Delete</Button>
                     }
                     else if (_plan.Status is MealPlanStatus.Active)
@@ -104,11 +105,13 @@
                         <Button Variant="ButtonVariant.Primary" OnClick="NavigateToEditDetails">Edit Details</Button>
                         <Button Variant="ButtonVariant.Outline" OnClick="NavigateToEdit">Edit Meals</Button>
                         <Button Variant="ButtonVariant.Outline" OnClick="DuplicatePlan">Duplicate</Button>
+                        <a href="/api/meal-plans/@_plan.Id/pdf" target="_blank" class="btn btn-outline" download>Export PDF</a>
                         <Button Variant="ButtonVariant.Ghost" OnClick="ArchivePlan">Archive</Button>
                     }
                     else if (_plan.Status is MealPlanStatus.Archived)
                     {
                         <Button Variant="ButtonVariant.Outline" OnClick="DuplicatePlan">Duplicate</Button>
+                        <a href="/api/meal-plans/@_plan.Id/pdf" target="_blank" class="btn btn-outline" download>Export PDF</a>
                         <Button Variant="ButtonVariant.Ghost" OnClick="ReactivatePlan">Reactivate</Button>
                     }
                 </div>

--- a/src/Nutrir.Web/Endpoints/MealPlanEndpoints.cs
+++ b/src/Nutrir.Web/Endpoints/MealPlanEndpoints.cs
@@ -1,0 +1,27 @@
+using System.Security.Claims;
+using Nutrir.Core.Interfaces;
+
+namespace Nutrir.Web.Endpoints;
+
+public static class MealPlanEndpoints
+{
+    public static void MapMealPlanEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/meal-plans")
+            .RequireAuthorization(policy => policy.RequireRole("Admin", "Nutritionist", "Assistant"));
+
+        group.MapGet("/{id:int}/pdf", async (int id, IMealPlanPdfService pdfService, IMealPlanService mealPlanService, HttpContext ctx) =>
+        {
+            var userId = ctx.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+
+            var plan = await mealPlanService.GetByIdAsync(id);
+            if (plan is null)
+                return Results.NotFound();
+
+            var pdfBytes = await pdfService.GeneratePdfAsync(id, userId);
+            var fileName = $"MealPlan-{plan.ClientLastName}-{plan.StartDate?.ToString("yyyy-MM-dd") ?? "undated"}.pdf";
+
+            return Results.File(pdfBytes, "application/pdf", fileName);
+        });
+    }
+}

--- a/src/Nutrir.Web/Program.cs
+++ b/src/Nutrir.Web/Program.cs
@@ -144,6 +144,9 @@ try
     // Consent form API endpoints.
     app.MapConsentFormEndpoints();
 
+    // Meal plan API endpoints.
+    app.MapMealPlanEndpoints();
+
     // SignalR hub for real-time notifications.
     app.MapHub<NutrirHub>("/hubs/nutrir");
 


### PR DESCRIPTION
## Summary
- **QuestPDF renderer** with branded header, day panels with macro totals, item tables with alternating rows, and page footer with page numbers
- **Service + interface** (`IMealPlanPdfService` / `MealPlanPdfService`) that loads the plan, renders PDF, and writes an audit log entry
- **Minimal API endpoint** `GET /api/meal-plans/{id}/pdf` with role-based auth (`Admin`, `Nutritionist`, `Assistant`), returning the PDF with a descriptive filename
- **"Export PDF" button** on the meal plan detail page for all statuses (Draft, Active, Archived) — native anchor tag, no JS interop needed
- **AI assistant tool** `export_meal_plan_pdf` that returns a download URL for the plan PDF
- **Layout spec** at `docs/meal-plans/pdf-export-layout.md`

Closes #139, closes #115, closes #118, closes #120, closes #123

## Test plan
- [ ] `dotnet build` passes with 0 errors/warnings
- [ ] Navigate to a meal plan detail page → click "Export PDF" → PDF downloads with correct layout
- [ ] Verify header shows branding, client name, date range, practitioner, status, and macro targets
- [ ] Verify day panels render with slot headers, item tables, and totals
- [ ] Test with varying plan sizes (1 day, 7 days, empty slots, many items spanning pages)
- [ ] Check Seq audit logs for `MealPlanPdfExported` entries
- [ ] Test AI tool: ask "export meal plan 1 as PDF" → verify download link returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)