### PR TITLE
feat: add monthly practice reports page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Organized by domain. Each folder contains specs, designs, and decisions for that
 | `design-system/` | Component API docs, design tokens, style guidelines |
 | `infrastructure/` | Docker, deployment, database, logging, hosting |
 | `compliance/` | Privacy laws, data handling, consent, regulatory |
+| `reports/` | Practice reports, analytics, metrics |
 | `temp/` | Drafts and work-in-progress — move to proper folder when finalized |
 
 ## Infrastructure Documents
@@ -61,6 +62,12 @@ Organized by domain. Each folder contains specs, designs, and decisions for that
 |----------|-------------|
 | [Calendar View](scheduling/calendar-view.md) | PoC spec — Radzen Blazor Scheduler integration for appointment calendar view |
 | [Domain Summary](scheduling/domain-summary.md) | Current state of the scheduling domain — entities, services, gaps |
+
+## Reports Documents
+
+| Document | Description |
+|----------|-------------|
+| [Practice Reports Spec](reports/practice-reports-spec.md) | Monthly practice reports — metrics, trend data, period options, UI layout |
 
 ## Architecture Decision Records
 

--- a/docs/reports/practice-reports-spec.md
+++ b/docs/reports/practice-reports-spec.md
@@ -1,0 +1,59 @@
+# Practice Reports Specification
+
+## Overview
+
+Monthly Practice Reports provide practitioners with summary metrics and trends for their practice. The reports page displays key performance indicators (KPIs), trend charts, and appointment breakdowns for configurable time periods.
+
+## Metrics
+
+| Metric | Calculation |
+|--------|------------|
+| Total Visits | Count of appointments with `Status == Completed` in period |
+| New Clients | Count of clients with `CreatedAt` within period |
+| Returning Clients | Clients with a completed appointment in period who were created *before* the period start |
+| No-Show Count | Count of appointments with `Status == NoShow` in period |
+| No-Show Rate | `NoShowCount / TotalScheduledAppointments * 100` (where scheduled = all non-cancelled) |
+| Cancellation Count | Count of appointments with `Status == Cancelled` or `Status == LateCancellation` in period |
+| Cancellation Rate | `CancellationCount / TotalAppointments * 100` |
+| Active Clients | Distinct clients with at least one appointment (any status except `Cancelled`) in period |
+| Appointments by Type | Breakdown count by `AppointmentType` (`InitialConsultation`, `FollowUp`, `CheckIn`) |
+
+## Period Options
+
+| Period | Date Range |
+|--------|-----------|
+| This Week | Monday of current week through Sunday |
+| This Month | First day of current month through last day |
+| This Quarter | First day of current quarter through last day |
+| Custom Range | User-selected start and end dates |
+
+## Trend Data
+
+Trend data groups metrics into time buckets for charting:
+
+| Period Length | Bucket Size |
+|--------------|-------------|
+| Up to 14 days | Daily |
+| 15 to 90 days | Weekly |
+| Over 90 days | Monthly |
+
+Each bucket contains: visits, no-shows, and cancellations.
+
+## UI Layout
+
+1. **Header** with breadcrumb and page title
+2. **Period selector** buttons (This Week / This Month / This Quarter / Custom)
+3. **Custom date range** inputs (shown when Custom is selected)
+4. **KPI metric cards** row: Total Visits, New Clients, No-Show Rate, Cancellation Rate
+5. **Trend chart** — grouped bar chart (visits, no-shows, cancellations over time)
+6. **Appointments by type** table breakdown
+
+## Data Sources
+
+- **Appointments**: `Appointment` entity — `Status`, `Type`, `StartTime`, `ClientId`
+- **Clients**: `Client` entity — `CreatedAt`, `Id`
+
+## Extensibility
+
+- Per-practitioner filtering planned as future enhancement (filter by `NutritionistId`)
+- Additional metrics (revenue, retention rate) may be added in future milestones

--- a/src/Nutrir.Core/DTOs/PracticeSummaryDto.cs
+++ b/src/Nutrir.Core/DTOs/PracticeSummaryDto.cs
@@ -1,0 +1,17 @@
+namespace Nutrir.Core.DTOs;
+
+public record PracticeSummaryDto(
+    int TotalVisits,
+    int NewClients,
+    int ReturningClients,
+    int NoShowCount,
+    decimal NoShowRate,
+    int CancellationCount,
+    decimal CancellationRate,
+    int ActiveClients,
+    List<AppointmentsByTypeDto> AppointmentsByType,
+    List<TrendBucketDto> TrendData);
+
+public record AppointmentsByTypeDto(string Type, int Count);
+
+public record TrendBucketDto(DateTime PeriodStart, string Label, int Visits, int NoShows, int Cancellations);

--- a/src/Nutrir.Core/Interfaces/IReportService.cs
+++ b/src/Nutrir.Core/Interfaces/IReportService.cs
@@ -1,0 +1,6 @@
+namespace Nutrir.Core.Interfaces;
+
+public interface IReportService
+{
+    Task<Core.DTOs.PracticeSummaryDto> GetPracticeSummaryAsync(DateTime startDate, DateTime endDate);
+}

--- a/src/Nutrir.Infrastructure/DependencyInjection.cs
+++ b/src/Nutrir.Infrastructure/DependencyInjection.cs
@@ -35,6 +35,7 @@ public static class DependencyInjection
         services.AddScoped<IMealPlanService, MealPlanService>();
         services.AddScoped<IProgressService, ProgressService>();
         services.AddScoped<ISearchService, SearchService>();
+        services.AddScoped<IReportService, ReportService>();
         services.AddScoped<ITimeZoneService, TimeZoneService>();
 
         services.AddSingleton<IMaintenanceService, MaintenanceService>();

--- a/src/Nutrir.Infrastructure/Services/ReportService.cs
+++ b/src/Nutrir.Infrastructure/Services/ReportService.cs
@@ -1,0 +1,137 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Nutrir.Core.DTOs;
+using Nutrir.Core.Enums;
+using Nutrir.Core.Interfaces;
+using Nutrir.Infrastructure.Data;
+
+namespace Nutrir.Infrastructure.Services;
+
+public class ReportService : IReportService
+{
+    private readonly IDbContextFactory<AppDbContext> _dbContextFactory;
+    private readonly ILogger<ReportService> _logger;
+
+    public ReportService(IDbContextFactory<AppDbContext> dbContextFactory, ILogger<ReportService> logger)
+    {
+        _dbContextFactory = dbContextFactory;
+        _logger = logger;
+    }
+
+    public async Task<PracticeSummaryDto> GetPracticeSummaryAsync(DateTime startDate, DateTime endDate)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync();
+
+        var appointments = await db.Appointments
+            .Where(a => a.StartTime >= startDate && a.StartTime < endDate)
+            .Select(a => new AppointmentSlim(a.Status, a.Type, a.StartTime, a.ClientId))
+            .ToListAsync();
+
+        var totalVisits = appointments.Count(a => a.Status == AppointmentStatus.Completed);
+
+        var newClients = await db.Clients
+            .CountAsync(c => c.CreatedAt >= startDate && c.CreatedAt < endDate);
+
+        var completedClientIds = appointments
+            .Where(a => a.Status == AppointmentStatus.Completed)
+            .Select(a => a.ClientId)
+            .Distinct()
+            .ToList();
+
+        var returningClients = completedClientIds.Count > 0
+            ? await db.Clients
+                .CountAsync(c => completedClientIds.Contains(c.Id) && c.CreatedAt < startDate)
+            : 0;
+
+        var noShowCount = appointments.Count(a => a.Status == AppointmentStatus.NoShow);
+        var cancellationCount = appointments.Count(a =>
+            a.Status == AppointmentStatus.Cancelled || a.Status == AppointmentStatus.LateCancellation);
+
+        var totalAppointments = appointments.Count;
+        var noShowRate = totalAppointments > 0
+            ? Math.Round((decimal)noShowCount / totalAppointments * 100, 1)
+            : 0m;
+        var cancellationRate = totalAppointments > 0
+            ? Math.Round((decimal)cancellationCount / totalAppointments * 100, 1)
+            : 0m;
+
+        var activeClients = appointments
+            .Where(a => a.Status != AppointmentStatus.Cancelled)
+            .Select(a => a.ClientId)
+            .Distinct()
+            .Count();
+
+        var appointmentsByType = appointments
+            .GroupBy(a => a.Type)
+            .Select(g => new AppointmentsByTypeDto(g.Key.ToString(), g.Count()))
+            .OrderByDescending(x => x.Count)
+            .ToList();
+
+        var trendData = BuildTrendBuckets(appointments, startDate, endDate);
+
+        _logger.LogInformation("Generated practice summary for {Start:d} to {End:d}: {Visits} visits, {New} new clients",
+            startDate, endDate, totalVisits, newClients);
+
+        return new PracticeSummaryDto(
+            totalVisits, newClients, returningClients,
+            noShowCount, noShowRate,
+            cancellationCount, cancellationRate,
+            activeClients, appointmentsByType, trendData);
+    }
+
+    private static bool IsCancellation(AppointmentStatus status) =>
+        status == AppointmentStatus.Cancelled || status == AppointmentStatus.LateCancellation;
+
+    private static List<TrendBucketDto> BuildTrendBuckets(
+        List<AppointmentSlim> appointments,
+        DateTime startDate,
+        DateTime endDate)
+    {
+        var totalDays = (endDate - startDate).TotalDays;
+        var buckets = new List<TrendBucketDto>();
+
+        if (totalDays <= 14)
+        {
+            for (var date = startDate.Date; date < endDate.Date; date = date.AddDays(1))
+            {
+                var nextDate = date.AddDays(1);
+                var bucket = appointments.Where(a => a.StartTime >= date && a.StartTime < nextDate).ToList();
+                buckets.Add(MakeBucket(date, date.ToString("MMM d"), bucket));
+            }
+        }
+        else if (totalDays <= 90)
+        {
+            var weekStart = startDate.Date;
+            while (weekStart < endDate)
+            {
+                var weekEnd = weekStart.AddDays(7) < endDate ? weekStart.AddDays(7) : endDate;
+                var bucket = appointments.Where(a => a.StartTime >= weekStart && a.StartTime < weekEnd).ToList();
+                buckets.Add(MakeBucket(weekStart, $"W{System.Globalization.ISOWeek.GetWeekOfYear(weekStart)}", bucket));
+                weekStart = weekEnd;
+            }
+        }
+        else
+        {
+            var monthStart = new DateTime(startDate.Year, startDate.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+            while (monthStart < endDate)
+            {
+                var monthEnd = monthStart.AddMonths(1);
+                var bucketStart = monthStart < startDate ? startDate : monthStart;
+                var bucketEnd = monthEnd > endDate ? endDate : monthEnd;
+                var bucket = appointments.Where(a => a.StartTime >= bucketStart && a.StartTime < bucketEnd).ToList();
+                buckets.Add(MakeBucket(monthStart, monthStart.ToString("MMM yyyy"), bucket));
+                monthStart = monthEnd;
+            }
+        }
+
+        return buckets;
+    }
+
+    private static TrendBucketDto MakeBucket(DateTime periodStart, string label, List<AppointmentSlim> bucket) =>
+        new(periodStart, label,
+            bucket.Count(a => a.Status == AppointmentStatus.Completed),
+            bucket.Count(a => a.Status == AppointmentStatus.NoShow),
+            bucket.Count(a => IsCancellation(a.Status)));
+
+    private record AppointmentSlim(AppointmentStatus Status, AppointmentType Type, DateTime StartTime, int ClientId);
+}

--- a/src/Nutrir.Web/Components/App.razor
+++ b/src/Nutrir.Web/Components/App.razor
@@ -27,6 +27,7 @@
     <script src="_framework/blazor.web.js"></script>
     <script src="lib/chart.js/chart.umd.min.js"></script>
     <script src="js/progress-chart.js"></script>
+    <script src="js/reports-chart.js"></script>
     <script src="js/global-search.js"></script>
     <script src="js/ai-panel.js"></script>
     <script src="js/context-menu.js"></script>

--- a/src/Nutrir.Web/Components/Layout/IconRailSidebar.razor
+++ b/src/Nutrir.Web/Components/Layout/IconRailSidebar.razor
@@ -31,6 +31,12 @@
             </svg>
         </NavLink>
 
+        <NavLink class="rail-item" href="reports" title="Reports">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/>
+            </svg>
+        </NavLink>
+
         <div class="rail-sep"></div>
 
         <NavLink class="rail-item" href="admin/users" title="Staff">

--- a/src/Nutrir.Web/Components/Pages/Reports/Reports.razor
+++ b/src/Nutrir.Web/Components/Pages/Reports/Reports.razor
@@ -1,0 +1,260 @@
+@page "/reports"
+@rendermode InteractiveServer
+@implements IAsyncDisposable
+
+@using Microsoft.AspNetCore.Authorization
+@using Nutrir.Core.DTOs
+@using Nutrir.Core.Interfaces
+
+@attribute [Authorize(Roles = "Admin,Nutritionist,Assistant")]
+
+@inject IReportService ReportService
+@inject IJSRuntime JS
+
+<PageTitle>Practice Reports — Nutrir</PageTitle>
+
+<Breadcrumb Items="@(new[] { new BreadcrumbItem("Reports") })" />
+
+<div class="reports-page">
+    <h1 class="reports-title">Practice Reports</h1>
+
+    <!-- Period Selector -->
+    <div class="reports-period-selector">
+        <button class="period-btn @(_selectedPeriod == Period.ThisWeek ? "active" : "")"
+                @onclick="() => SelectPeriod(Period.ThisWeek)">This Week</button>
+        <button class="period-btn @(_selectedPeriod == Period.ThisMonth ? "active" : "")"
+                @onclick="() => SelectPeriod(Period.ThisMonth)">This Month</button>
+        <button class="period-btn @(_selectedPeriod == Period.ThisQuarter ? "active" : "")"
+                @onclick="() => SelectPeriod(Period.ThisQuarter)">This Quarter</button>
+        <button class="period-btn @(_selectedPeriod == Period.Custom ? "active" : "")"
+                @onclick="() => SelectPeriod(Period.Custom)">Custom</button>
+    </div>
+
+    @if (_selectedPeriod == Period.Custom)
+    {
+        <div class="reports-custom-range">
+            <div class="custom-range-field">
+                <label for="startDate">Start Date</label>
+                <input type="date" id="startDate" value="@_customStart.ToString("yyyy-MM-dd")"
+                       @onchange="OnStartDateChanged" />
+            </div>
+            <div class="custom-range-field">
+                <label for="endDate">End Date</label>
+                <input type="date" id="endDate" value="@_customEnd.ToString("yyyy-MM-dd")"
+                       @onchange="OnEndDateChanged" />
+            </div>
+            <button class="period-btn active" @onclick="LoadData">Apply</button>
+        </div>
+    }
+
+    @if (_loading)
+    {
+        <div class="reports-loading">
+            <div class="cc-skeleton-metrics">
+                <div class="cc-skeleton cc-skeleton-metric"></div>
+                <div class="cc-skeleton cc-skeleton-metric"></div>
+                <div class="cc-skeleton cc-skeleton-metric"></div>
+                <div class="cc-skeleton cc-skeleton-metric"></div>
+            </div>
+            <div class="cc-skeleton cc-skeleton-chart"></div>
+        </div>
+    }
+    else if (_summary is not null)
+    {
+        <!-- KPI Cards -->
+        <div class="cc-metrics-bar">
+            <MetricCard Label="Total Visits"
+                        Value="@_summary.TotalVisits.ToString()" />
+            <MetricCard Label="New Clients"
+                        Value="@_summary.NewClients.ToString()"
+                        DeltaText="@(_summary.ReturningClients > 0 ? $"{_summary.ReturningClients} returning" : null)" />
+            <MetricCard Label="No-Show Rate"
+                        Value="@($"{_summary.NoShowRate}%")"
+                        DeltaText="@(_summary.NoShowCount > 0 ? $"{_summary.NoShowCount} total" : null)"
+                        Delta="@(_summary.NoShowCount > 0 ? MetricDelta.Down : MetricDelta.Flat)" />
+            <MetricCard Label="Cancellation Rate"
+                        Value="@($"{_summary.CancellationRate}%")"
+                        DeltaText="@(_summary.CancellationCount > 0 ? $"{_summary.CancellationCount} total" : null)"
+                        Delta="@(_summary.CancellationCount > 0 ? MetricDelta.Down : MetricDelta.Flat)" />
+        </div>
+
+        <!-- Additional Metrics -->
+        <div class="reports-secondary-metrics">
+            <span class="secondary-metric">
+                <strong>@_summary.ActiveClients</strong> Active Clients
+            </span>
+            <span class="secondary-metric">
+                <strong>@_summary.ReturningClients</strong> Returning Clients
+            </span>
+        </div>
+
+        <!-- Trend Chart -->
+        @if (_summary.TrendData.Count > 0)
+        {
+            <div class="reports-chart-card">
+                <h2 class="reports-section-title">Trends</h2>
+                <div class="reports-chart-wrapper">
+                    <canvas id="@_canvasId"></canvas>
+                </div>
+            </div>
+        }
+
+        <!-- Appointments by Type -->
+        @if (_summary.AppointmentsByType.Count > 0)
+        {
+            <div class="reports-type-card">
+                <h2 class="reports-section-title">Appointments by Type</h2>
+                <table class="reports-type-table">
+                    <thead>
+                        <tr>
+                            <th>Type</th>
+                            <th>Count</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in _summary.AppointmentsByType)
+                        {
+                            <tr>
+                                <td>@FormatTypeName(item.Type)</td>
+                                <td>@item.Count</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+
+        @if (_summary.TotalVisits == 0 && _summary.NewClients == 0 && _summary.ActiveClients == 0)
+        {
+            <div class="reports-empty">
+                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity: 0.4;">
+                    <line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/>
+                </svg>
+                <p>No data for the selected period</p>
+            </div>
+        }
+    }
+</div>
+
+@code {
+    private enum Period { ThisWeek, ThisMonth, ThisQuarter, Custom }
+
+    private Period _selectedPeriod = Period.ThisMonth;
+    private DateTime _customStart = DateTime.UtcNow.AddMonths(-1).Date;
+    private DateTime _customEnd = DateTime.UtcNow.Date;
+    private bool _loading = true;
+    private PracticeSummaryDto? _summary;
+    private string _canvasId = $"reports-chart-{Guid.NewGuid():N}";
+    private bool _chartRendered;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadData();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_summary is not null && _summary.TrendData.Count > 0 && !_chartRendered)
+        {
+            await RenderChart();
+        }
+    }
+
+    private async Task SelectPeriod(Period period)
+    {
+        _selectedPeriod = period;
+        if (period != Period.Custom)
+        {
+            await LoadData();
+        }
+    }
+
+    private void OnStartDateChanged(ChangeEventArgs e)
+    {
+        if (DateTime.TryParse(e.Value?.ToString(), out var date))
+            _customStart = DateTime.SpecifyKind(date, DateTimeKind.Utc);
+    }
+
+    private void OnEndDateChanged(ChangeEventArgs e)
+    {
+        if (DateTime.TryParse(e.Value?.ToString(), out var date))
+            _customEnd = DateTime.SpecifyKind(date, DateTimeKind.Utc);
+    }
+
+    private (DateTime Start, DateTime End) GetDateRange()
+    {
+        var now = DateTime.UtcNow;
+        return _selectedPeriod switch
+        {
+            Period.ThisWeek => (now.Date.AddDays(-(int)now.DayOfWeek + (int)DayOfWeek.Monday),
+                                now.Date.AddDays(-(int)now.DayOfWeek + (int)DayOfWeek.Monday + 7)),
+            Period.ThisMonth => (new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc),
+                                 new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc).AddMonths(1)),
+            Period.ThisQuarter => GetQuarterRange(now),
+            Period.Custom => (_customStart, _customEnd.AddDays(1)),
+            _ => (now.Date.AddDays(-30), now.Date.AddDays(1))
+        };
+    }
+
+    private static (DateTime Start, DateTime End) GetQuarterRange(DateTime now)
+    {
+        var quarterMonth = ((now.Month - 1) / 3) * 3 + 1;
+        var start = new DateTime(now.Year, quarterMonth, 1, 0, 0, 0, DateTimeKind.Utc);
+        return (start, start.AddMonths(3));
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        await DestroyChart();
+
+        var (start, end) = GetDateRange();
+        _summary = await ReportService.GetPracticeSummaryAsync(start, end);
+
+        _loading = false;
+        _chartRendered = false;
+    }
+
+    private async Task RenderChart()
+    {
+        if (_summary is null) return;
+
+        var labels = _summary.TrendData.Select(t => t.Label).ToArray();
+        var visits = _summary.TrendData.Select(t => t.Visits).ToArray();
+        var noShows = _summary.TrendData.Select(t => t.NoShows).ToArray();
+        var cancellations = _summary.TrendData.Select(t => t.Cancellations).ToArray();
+
+        try
+        {
+            await JS.InvokeVoidAsync("reportsChart.create", _canvasId, labels, visits, noShows, cancellations);
+            _chartRendered = true;
+        }
+        catch (JSException) { }
+    }
+
+    private async Task DestroyChart()
+    {
+        if (_chartRendered)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("reportsChart.destroy", _canvasId);
+                _chartRendered = false;
+            }
+            catch (JSException) { }
+        }
+    }
+
+    private static string FormatTypeName(string type) => type switch
+    {
+        "InitialConsultation" => "Initial Consultation",
+        "FollowUp" => "Follow-Up",
+        "CheckIn" => "Check-In",
+        _ => type
+    };
+
+    public async ValueTask DisposeAsync()
+    {
+        await DestroyChart();
+    }
+}

--- a/src/Nutrir.Web/Components/Pages/Reports/Reports.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Reports/Reports.razor.css
@@ -1,0 +1,173 @@
+.reports-page {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 1rem 2rem;
+}
+
+.reports-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0 0 1.25rem;
+    color: var(--color-text);
+}
+
+/* Period Selector */
+.reports-period-selector {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+}
+
+.period-btn {
+    padding: 0.4rem 0.875rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.period-btn:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.period-btn.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+}
+
+/* Custom Range */
+.reports-custom-range {
+    display: flex;
+    align-items: end;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+}
+
+.custom-range-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.custom-range-field label {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+}
+
+.custom-range-field input[type="date"] {
+    padding: 0.4rem 0.625rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    font-size: 0.8125rem;
+    background: var(--color-surface);
+    color: var(--color-text);
+}
+
+/* Secondary Metrics */
+.reports-secondary-metrics {
+    display: flex;
+    gap: 1.5rem;
+    margin: 0.75rem 0 1.25rem;
+    flex-wrap: wrap;
+}
+
+.secondary-metric {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+}
+
+.secondary-metric strong {
+    color: var(--color-text);
+    font-weight: 600;
+}
+
+/* Chart Card */
+.reports-chart-card,
+.reports-type-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    padding: 1.25rem;
+    margin-bottom: 1.25rem;
+}
+
+.reports-section-title {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0 0 1rem;
+}
+
+.reports-chart-wrapper {
+    position: relative;
+    height: 280px;
+}
+
+/* Type Table */
+.reports-type-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+}
+
+.reports-type-table th {
+    text-align: left;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.reports-type-table td {
+    padding: 0.625rem 0.75rem;
+    border-bottom: 1px solid var(--color-border-light, var(--color-border));
+    color: var(--color-text);
+}
+
+.reports-type-table tr:last-child td {
+    border-bottom: none;
+}
+
+.reports-type-table td:last-child {
+    font-weight: 600;
+    text-align: right;
+}
+
+.reports-type-table th:last-child {
+    text-align: right;
+}
+
+/* Loading */
+.reports-loading {
+    margin-top: 1rem;
+}
+
+::deep .cc-skeleton-chart {
+    height: 280px;
+    border-radius: 10px;
+    margin-top: 1rem;
+}
+
+/* Empty State */
+.reports-empty {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--color-text-muted);
+}
+
+.reports-empty p {
+    margin: 0.75rem 0 0;
+    font-size: 0.875rem;
+}

--- a/src/Nutrir.Web/wwwroot/js/reports-chart.js
+++ b/src/Nutrir.Web/wwwroot/js/reports-chart.js
@@ -1,0 +1,98 @@
+window.reportsChart = {
+    _instances: {},
+
+    create: function (canvasId, labels, visitData, noShowData, cancellationData) {
+        this.destroy(canvasId);
+
+        const canvas = document.getElementById(canvasId);
+        if (!canvas) return;
+
+        const ctx = canvas.getContext('2d');
+
+        const styles = getComputedStyle(document.documentElement);
+        const primary = styles.getPropertyValue('--color-primary').trim() || '#7c3aed';
+        const warning = styles.getPropertyValue('--color-warning').trim() || '#f59e0b';
+        const danger = styles.getPropertyValue('--color-danger').trim() || '#ef4444';
+        const textColor = styles.getPropertyValue('--color-text-muted').trim() || '#6b7280';
+        const borderColor = styles.getPropertyValue('--color-border').trim() || '#e5e7eb';
+
+        this._instances[canvasId] = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'Visits',
+                        data: visitData,
+                        backgroundColor: primary + 'cc',
+                        borderColor: primary,
+                        borderWidth: 1,
+                        borderRadius: 3
+                    },
+                    {
+                        label: 'No-Shows',
+                        data: noShowData,
+                        backgroundColor: warning + 'cc',
+                        borderColor: warning,
+                        borderWidth: 1,
+                        borderRadius: 3
+                    },
+                    {
+                        label: 'Cancellations',
+                        data: cancellationData,
+                        backgroundColor: danger + 'cc',
+                        borderColor: danger,
+                        borderWidth: 1,
+                        borderRadius: 3
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: {
+                        display: true,
+                        position: 'top',
+                        labels: {
+                            color: textColor,
+                            font: { size: 12 },
+                            boxWidth: 12
+                        }
+                    },
+                    tooltip: {
+                        mode: 'index',
+                        intersect: false
+                    }
+                },
+                scales: {
+                    x: {
+                        ticks: { color: textColor, font: { size: 11 } },
+                        grid: { color: borderColor }
+                    },
+                    y: {
+                        beginAtZero: true,
+                        ticks: {
+                            color: textColor,
+                            font: { size: 11 },
+                            stepSize: 1
+                        },
+                        grid: { color: borderColor }
+                    }
+                },
+                interaction: {
+                    mode: 'nearest',
+                    axis: 'x',
+                    intersect: false
+                }
+            }
+        });
+    },
+
+    destroy: function (canvasId) {
+        if (this._instances[canvasId]) {
+            this._instances[canvasId].destroy();
+            delete this._instances[canvasId];
+        }
+    }
+};


### PR DESCRIPTION
## Summary

- **#109**: Add practice reports spec document (`docs/reports/practice-reports-spec.md`) defining metrics, period options, trend bucketing, and UI layout
- **#112**: Implement `IReportService` with `PracticeSummaryDto` — queries appointments/clients for visits, no-show/cancellation rates, active/new/returning clients, appointments by type, and daily/weekly/monthly trend buckets
- **#114**: Build `/reports` page with period selector (This Week/Month/Quarter/Custom), KPI metric cards, Chart.js grouped bar chart for trends, appointments-by-type table, and loading/empty states
- **#116**: Add Reports nav link with bar-chart icon to sidebar, positioned after Meal Plans

## Test plan

- [ ] `dotnet build` passes with 0 errors/warnings
- [ ] Navigate to `/reports` — page loads with This Month selected by default
- [ ] Switch between This Week, This Month, This Quarter — data and chart update
- [ ] Select Custom, pick a date range, click Apply — data reflects custom range
- [ ] Verify KPI cards show correct values (Total Visits, New Clients, No-Show Rate, Cancellation Rate)
- [ ] Verify trend chart renders grouped bars for visits, no-shows, cancellations
- [ ] Verify appointments-by-type table shows breakdown
- [ ] Verify empty state displays when no data exists for selected period
- [ ] Verify Reports icon highlights in sidebar when on `/reports`
- [ ] Check Seq logs for no errors

Closes #109, closes #112, closes #114, closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)