### PR TITLE
fix: align meal slot table columns across slots

### DIFF
--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor
@@ -198,6 +198,14 @@
                                 @if (slot.Items.Count > 0)
                                 {
                                     <table class="items-table">
+                                        <colgroup>
+                                            <col />
+                                            <col style="width: 12%;" />
+                                            <col style="width: 10%;" />
+                                            <col style="width: 8%;" />
+                                            <col style="width: 8%;" />
+                                            <col style="width: 8%;" />
+                                        </colgroup>
                                         <thead>
                                             <tr>
                                                 <th>Food</th>

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor.css
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor.css
@@ -297,6 +297,7 @@
 /* ── Items Table ─────────────────────────────────────── */
 .items-table {
     width: 100%;
+    table-layout: fixed;
     font-size: var(--text-xs);
     border-collapse: collapse;
 }

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor
@@ -110,6 +110,16 @@
                     @if (slot.Items.Count > 0)
                     {
                         <table class="items-table">
+                            <colgroup>
+                                <col />
+                                <col style="width: 10%;" />
+                                <col style="width: 10%;" />
+                                <col style="width: 10%;" />
+                                <col style="width: 8%;" />
+                                <col style="width: 8%;" />
+                                <col style="width: 8%;" />
+                                <col style="width: 4%;" />
+                            </colgroup>
                             <thead>
                                 <tr>
                                     <th>Food</th>

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor.css
@@ -242,6 +242,7 @@
 /* ── Items Table ─────────────────────────────────────── */
 .items-table {
     width: 100%;
+    table-layout: fixed;
     font-size: var(--text-xs);
     border-collapse: collapse;
 }


### PR DESCRIPTION
## Summary
- Add `table-layout: fixed` and `<colgroup>` elements to meal slot tables on both detail and edit views
- Ensures columns (Food, Qty, Cal, P, C, F) align consistently across all meal slots within a day

## Test plan
- [ ] Navigate to a meal plan detail page with multiple slots (e.g. Breakfast + Lunch) and verify columns align vertically
- [ ] Navigate to the edit view and verify the same alignment
- [ ] Check no horizontal overflow on standard screen widths
- [ ] Verify mobile responsiveness is unaffected

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)