### PR TITLE
feat: add nginx reverse proxy configs and deployment guide

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,117 @@
+# Deployment Guide
+
+## Prerequisites
+
+- Docker & Docker Compose installed
+- Nginx installed (`sudo apt install nginx`)
+- Certbot installed (`sudo apt install certbot`)
+- `.env` file with required variables (see `docker-compose.prod.yml`)
+
+## 1. Start the Application
+
+```bash
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Verify it's running:
+
+```bash
+curl -I http://127.0.0.1:8080
+```
+
+## 2. Set Up HTTP Nginx Config (for Certbot)
+
+```bash
+sudo mkdir -p /var/www/certbot
+sudo ln -s $(pwd)/deploy/nginx/elisamtz.nutrir.ca.http.conf /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Verify HTTP proxy works:
+
+```bash
+curl -I http://elisamtz.nutrir.ca
+```
+
+## 3. Obtain SSL Certificate
+
+```bash
+sudo certbot certonly --webroot -w /var/www/certbot -d elisamtz.nutrir.ca
+```
+
+## 4. Switch to HTTPS Nginx Config
+
+```bash
+sudo rm /etc/nginx/sites-enabled/elisamtz.nutrir.ca.http.conf
+sudo ln -s $(pwd)/deploy/nginx/elisamtz.nutrir.ca.conf /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Verify HTTPS works:
+
+```bash
+curl -I https://elisamtz.nutrir.ca
+```
+
+## 5. Verify Auto-Renewal
+
+```bash
+sudo certbot renew --dry-run
+```
+
+Certbot installs a systemd timer by default. Verify it's active:
+
+```bash
+sudo systemctl status certbot.timer
+```
+
+## Updating the Application
+
+```bash
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+```
+
+---
+
+# Static Site: nutrir.ca
+
+## 1. Create Site Root and Add Content
+
+```bash
+sudo mkdir -p /var/www/nutrir.ca
+# Place your index.html and static assets here
+```
+
+## 2. Set Up HTTP Nginx Config (for Certbot)
+
+```bash
+sudo ln -s $(pwd)/deploy/nginx/nutrir.ca.http.conf /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+## 3. Obtain SSL Certificate
+
+```bash
+sudo certbot certonly --webroot -w /var/www/certbot -d nutrir.ca -d www.nutrir.ca
+```
+
+## 4. Switch to HTTPS Nginx Config
+
+```bash
+sudo rm /etc/nginx/sites-enabled/nutrir.ca.http.conf
+sudo ln -s $(pwd)/deploy/nginx/nutrir.ca.conf /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+---
+
+# Notes
+
+## `map` Directive
+
+The elisamtz nginx configs include a `map $http_upgrade $connection_upgrade` block for WebSocket support. If you have multiple sites using this directive, move it to `/etc/nginx/conf.d/websocket-map.conf` and remove it from individual site configs to avoid duplicates.

--- a/deploy/nginx/elisamtz.nutrir.ca.conf
+++ b/deploy/nginx/elisamtz.nutrir.ca.conf
@@ -1,0 +1,58 @@
+# Redirect HTTP to HTTPS (keep certbot challenge on port 80)
+server {
+    listen 80;
+    listen [::]:80;
+    server_name elisamtz.nutrir.ca;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS server
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name elisamtz.nutrir.ca;
+
+    # SSL certificates (managed by certbot)
+    ssl_certificate     /etc/letsencrypt/live/elisamtz.nutrir.ca/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/elisamtz.nutrir.ca/privkey.pem;
+
+    # SSL hardening
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    # HSTS (1 year)
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    # OCSP stapling
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /etc/letsencrypt/live/elisamtz.nutrir.ca/chain.pem;
+
+    # Proxy to app
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket support for Blazor Server SignalR
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}

--- a/deploy/nginx/elisamtz.nutrir.ca.http.conf
+++ b/deploy/nginx/elisamtz.nutrir.ca.http.conf
@@ -1,0 +1,30 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name elisamtz.nutrir.ca;
+
+    # Certbot webroot validation
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # Proxy to app
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket support for Blazor Server SignalR
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}

--- a/deploy/nginx/nutrir.ca.conf
+++ b/deploy/nginx/nutrir.ca.conf
@@ -1,0 +1,57 @@
+# Redirect HTTP to HTTPS (keep certbot challenge on port 80)
+server {
+    listen 80;
+    listen [::]:80;
+    server_name nutrir.ca www.nutrir.ca;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# Redirect www to apex
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name www.nutrir.ca;
+
+    ssl_certificate     /etc/letsencrypt/live/nutrir.ca/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/nutrir.ca/privkey.pem;
+
+    return 301 https://nutrir.ca$request_uri;
+}
+
+# HTTPS server
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name nutrir.ca;
+
+    # SSL certificates (managed by certbot)
+    ssl_certificate     /etc/letsencrypt/live/nutrir.ca/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/nutrir.ca/privkey.pem;
+
+    # SSL hardening
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    # HSTS (1 year)
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    # OCSP stapling
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /etc/letsencrypt/live/nutrir.ca/chain.pem;
+
+    # Serve static content
+    location / {
+        root /var/www/nutrir.ca;
+        index index.html;
+        try_files $uri $uri/ =404;
+    }
+}

--- a/deploy/nginx/nutrir.ca.http.conf
+++ b/deploy/nginx/nutrir.ca.http.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name nutrir.ca www.nutrir.ca;
+
+    # Certbot webroot validation
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # Serve static content
+    location / {
+        root /var/www/nutrir.ca;
+        index index.html;
+        try_files $uri $uri/ =404;
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,7 @@ services:
   app:
     image: ghcr.io/cpike5/nutrir:latest
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Add nginx configs for `elisamtz.nutrir.ca` (Blazor app reverse proxy with WebSocket/SignalR support) and `nutrir.ca` (static HTML site with www-to-apex redirect)
- Include HTTP-only configs for certbot bootstrapping and HTTPS configs with TLS 1.2+, HSTS, and OCSP stapling
- Bind production Docker port to `127.0.0.1:8080` so only nginx handles external traffic
- Add step-by-step deployment README covering both sites

## Test plan
- [ ] `docker compose -f docker-compose.prod.yml config` validates successfully
- [ ] Symlink HTTP conf, reload nginx, verify `curl -I http://elisamtz.nutrir.ca` proxies to app
- [ ] Run `certbot certonly --webroot` for both domains
- [ ] Switch to HTTPS confs, verify `curl -I https://elisamtz.nutrir.ca` and `https://nutrir.ca`
- [ ] Verify `certbot renew --dry-run` succeeds
- [ ] Confirm WebSocket upgrade works for Blazor Server SignalR (`/_blazor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)