### PR TITLE
fix: restyle edit appointment time selector to match create form

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Appointments/AppointmentEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/Appointments/AppointmentEdit.razor
@@ -137,6 +137,15 @@
                             </div>
                         </div>
                     }
+                    else if (_slotsLoaded && !_isLoadingSlots)
+                    {
+                        <p class="no-slots-msg">No available slots for this date and duration.</p>
+                    }
+
+                    @if (_isLoadingSlots)
+                    {
+                        <p class="slots-loading">Loading available slots...</p>
+                    }
 
                     @if (!string.IsNullOrEmpty(_availabilityWarning))
                     {
@@ -209,6 +218,8 @@
 
     // Availability slots
     private List<AvailableSlotDto> _availableSlots = [];
+    private bool _isLoadingSlots;
+    private bool _slotsLoaded;
     private string? _availabilityWarning;
 
     protected override async Task OnInitializedAsync()
@@ -351,20 +362,30 @@
         if (string.IsNullOrEmpty(_model.Date) || !DateOnly.TryParse(_model.Date, out var date))
         {
             _availableSlots = [];
+            _slotsLoaded = false;
             return;
         }
 
         if (!int.TryParse(_model.Duration, out var duration))
             duration = 30;
 
+        _isLoadingSlots = true;
+        StateHasChanged();
+
         try
         {
             _availableSlots = await AvailabilityService.GetAvailableSlotsAsync(_userId, date, duration);
+            _slotsLoaded = true;
             CheckTimeAgainstSlots();
         }
         catch
         {
             _availableSlots = [];
+            _slotsLoaded = false;
+        }
+        finally
+        {
+            _isLoadingSlots = false;
         }
     }
 
@@ -372,7 +393,7 @@
     {
         _availabilityWarning = null;
 
-        if (_availableSlots.Count == 0 || string.IsNullOrEmpty(_model.Time))
+        if (!_slotsLoaded || _availableSlots.Count == 0 || string.IsNullOrEmpty(_model.Time))
             return;
 
         if (!TimeOnly.TryParse(_model.Time, out var selectedTime))

--- a/src/Nutrir.Web/Components/Pages/Appointments/AppointmentEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Appointments/AppointmentEdit.razor.css
@@ -41,6 +41,13 @@
     color: white;
 }
 
+.no-slots-msg,
+.slots-loading {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    padding: var(--space-1) 0;
+}
+
 .availability-warning {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary

- Added `_isLoadingSlots` and `_slotsLoaded` state tracking to the edit appointment form, matching the create form's pattern
- Added "Loading available slots..." indicator and "No available slots" message
- Added `.no-slots-msg` and `.slots-loading` CSS styles matching the create form
- Added `!_slotsLoaded` guard to `CheckTimeAgainstSlots` for consistency

Closes #167

## Test plan

- [ ] Open the edit form for an existing appointment — verify slot buttons render with proper styling
- [ ] Change the date — verify "Loading available slots..." appears briefly during fetch
- [ ] Select a date with no availability — verify "No available slots for this date and duration." message appears
- [ ] Select a time outside available slots — verify warning appears with correct styling
- [ ] Compare visual appearance with the create form (`/appointments/new`) — time selector area should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)