### PR TITLE
fix: increase AI assistant bullet list padding and spacing

### DIFF
--- a/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor.css
+++ b/src/Nutrir.Web/Components/Layout/AiAssistantPanel.razor.css
@@ -202,13 +202,13 @@
 
 .cc-ai-msg--assistant .cc-ai-msg-content ul,
 .cc-ai-msg--assistant .cc-ai-msg-content ol {
-    margin: 0.25rem 0;
-    padding-left: var(--space-4);
+    margin: var(--space-2) 0;
+    padding-left: var(--space-5);
 }
 
 .cc-ai-msg--assistant .cc-ai-msg-content li {
     margin-left: 0;
-    margin-bottom: var(--space-1);
+    margin-bottom: var(--space-2);
     line-height: var(--leading-normal);
 }
 


### PR DESCRIPTION
## Summary

- Increased `ul`/`ol` margin from `0.25rem` to `var(--space-2)` (0.5rem) for better vertical separation from surrounding content
- Increased `padding-left` from `var(--space-4)` to `var(--space-5)` (1.25rem) for more natural bullet indentation
- Increased `li` margin-bottom from `var(--space-1)` to `var(--space-2)` (0.5rem) for easier scanning

Closes #169

## Test plan

- [ ] Run dashboard overview prompt ("give me a dashboard overview") and verify list spacing looks natural
- [ ] Verify short lists (2-3 items) and longer lists (5+) both look good
- [ ] Verify ordered lists (`ol`) also render correctly
- [ ] Check no regressions in other AI panel content (tables, headings, code blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)