### PR TITLE
feat: add text search/filter to Appointments list page

### DIFF
--- a/src/Nutrir.Core/DTOs/AppointmentListQuery.cs
+++ b/src/Nutrir.Core/DTOs/AppointmentListQuery.cs
@@ -9,4 +9,5 @@ public record AppointmentListQuery(
     SortDirection SortDirection = SortDirection.None,
     DateTime? From = null,
     DateTime? To = null,
-    AppointmentStatus? StatusFilter = null);
+    AppointmentStatus? StatusFilter = null,
+    string? SearchTerm = null);

--- a/src/Nutrir.Infrastructure/Services/AppointmentService.cs
+++ b/src/Nutrir.Infrastructure/Services/AppointmentService.cs
@@ -93,6 +93,17 @@ public class AppointmentService : IAppointmentService
         if (query.StatusFilter.HasValue)
             dbQuery = dbQuery.Where(a => a.Status == query.StatusFilter.Value);
 
+        // Text search filter (client name)
+        if (!string.IsNullOrWhiteSpace(query.SearchTerm))
+        {
+            var pattern = $"%{query.SearchTerm.Trim()}%";
+            dbQuery = dbQuery.Where(a =>
+                db.Clients.IgnoreQueryFilters().Any(c => c.Id == a.ClientId &&
+                    (EF.Functions.ILike(c.FirstName, pattern) ||
+                     EF.Functions.ILike(c.LastName, pattern) ||
+                     EF.Functions.ILike(c.FirstName + " " + c.LastName, pattern))));
+        }
+
         var totalCount = await dbQuery.CountAsync();
 
         // Determine if sorting by a column that requires in-memory sort

--- a/src/Nutrir.Web/Components/Pages/Appointments/AppointmentList.razor
+++ b/src/Nutrir.Web/Components/Pages/Appointments/AppointmentList.razor
@@ -40,6 +40,14 @@
               IsLoading="@_isLoading"
               ShowRealtimeBanner="@_refreshedByRealTime">
         <ToolbarContent>
+            <div class="filter-group filter-group--search">
+                <label for="filter-search" class="filter-label">Search</label>
+                <input type="search" id="filter-search" class="filter-input"
+                       placeholder="Client name…"
+                       value="@_searchTerm"
+                       @onchange="@(e => OnSearchChanged(e.Value?.ToString() ?? ""))" />
+            </div>
+            <div class="filter-divider" aria-hidden="true"></div>
             <div class="filter-group">
                 <label for="filter-from" class="filter-label">From</label>
                 <input type="date" id="filter-from" class="filter-input"
@@ -146,13 +154,21 @@
                 </svg>
                 <p class="empty-state-title">No appointments found</p>
                 <p class="empty-state-desc">
-                    @if (_query.StatusFilter is null)
+                    @if (!string.IsNullOrWhiteSpace(_searchTerm) && _query.StatusFilter is not null)
                     {
-                        <span>Schedule your first appointment to get started.</span>
+                        <span>No appointments matching '@_searchTerm' with the selected status filter.</span>
+                    }
+                    else if (!string.IsNullOrWhiteSpace(_searchTerm))
+                    {
+                        <span>No appointments matching '@_searchTerm'.</span>
+                    }
+                    else if (_query.StatusFilter is not null)
+                    {
+                        <span>Try adjusting your filters.</span>
                     }
                     else
                     {
-                        <span>Try adjusting your filters.</span>
+                        <span>Schedule your first appointment to get started.</span>
                     }
                 </p>
             </div>
@@ -161,10 +177,14 @@
 </div>
 
 @code {
+    [SupplyParameterFromQuery(Name = "q")]
+    public string? SearchQuery { get; set; }
+
     private PagedResult<AppointmentDto>? _result;
     private AppointmentListQuery _query = new();
     private string? _fromDate;
     private string? _toDate;
+    private string _searchTerm = "";
     private bool _isLoading = true;
     private bool _refreshedByRealTime;
     private System.Threading.Timer? _debounceTimer;
@@ -175,10 +195,29 @@
         NotificationService.OnEntityChanged += OnEntityChanged;
         await NotificationService.StartAsync();
         await TimeZoneService.InitializeAsync();
-        var now = TimeZoneService.UserNow;
-        _fromDate = now.ToString("yyyy-MM-dd");
-        _toDate = now.AddDays(7).ToString("yyyy-MM-dd");
+        ApplySearchQuery();
         await LoadDataAsync();
+    }
+
+    protected override void OnParametersSet()
+    {
+        ApplySearchQuery();
+    }
+
+    private void ApplySearchQuery()
+    {
+        if (!string.IsNullOrWhiteSpace(SearchQuery))
+        {
+            _searchTerm = SearchQuery;
+            _fromDate = null;
+            _toDate = null;
+        }
+        else if (string.IsNullOrWhiteSpace(_searchTerm))
+        {
+            var now = TimeZoneService.UserNow;
+            _fromDate = now.ToString("yyyy-MM-dd");
+            _toDate = now.AddDays(7).ToString("yyyy-MM-dd");
+        }
     }
 
     private async Task LoadDataAsync()
@@ -194,7 +233,7 @@
         if (DateTime.TryParse(_toDate, out var parsedTo))
             to = TimeZoneService.ToUtc(parsedTo.AddDays(1).AddTicks(-1));
 
-        _query = _query with { From = from, To = to };
+        _query = _query with { From = from, To = to, SearchTerm = string.IsNullOrWhiteSpace(_searchTerm) ? null : _searchTerm.Trim() };
         _result = await AppointmentService.GetPagedAsync(_query);
         _isLoading = false;
     }
@@ -230,6 +269,29 @@
             status = parsed;
         _query = _query with { StatusFilter = status, Page = 1 };
         DebouncedLoad();
+    }
+
+    private void OnSearchChanged(string value)
+    {
+        _searchTerm = value;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            // Restore default date range when clearing search
+            var now = TimeZoneService.UserNow;
+            _fromDate = now.ToString("yyyy-MM-dd");
+            _toDate = now.AddDays(7).ToString("yyyy-MM-dd");
+        }
+        _query = _query with { Page = 1 };
+        UpdateUrl();
+        DebouncedLoad();
+    }
+
+    private void UpdateUrl()
+    {
+        var uri = string.IsNullOrWhiteSpace(_searchTerm)
+            ? "/appointments"
+            : $"/appointments?q={Uri.EscapeDataString(_searchTerm)}";
+        NavigationManager.NavigateTo(uri, replace: true);
     }
 
     private void DebouncedLoad()


### PR DESCRIPTION
## Summary

- Wires up the `?q=` query parameter from GlobalSearch's "See all" link so the Appointments list page filters by client name (first, last, or full name — case-insensitive `ILIKE` via Npgsql)
- When a search term is active, the default 7-day date range is removed so results aren't constrained
- Adds a search text input to the DataGrid toolbar; clearing it restores the default date range
- URL updates on search change for shareability/bookmarkability
- Empty state reflects active search context (including combined search + status filter)

## Changes

| File | What |
|------|------|
| `AppointmentListQuery.cs` | Added `string? SearchTerm` parameter |
| `AppointmentService.cs` | Added `EF.Functions.ILike` correlated subquery on Client table in `GetPagedAsync` |
| `AppointmentList.razor` | `[SupplyParameterFromQuery]` for `q`, search input in toolbar, `OnParametersSet` sync, contextual empty state |

## Test plan

- [ ] Navigate to `/appointments?q=Jane` — should show all appointments for clients matching "Jane" with no date range constraint
- [ ] Use GlobalSearch, type a client name, click "See all" under Appointments — should land on filtered list
- [ ] Clear the search input — date range should restore to default 7-day window
- [ ] Combine search with status filter — empty state should mention both
- [ ] Verify URL updates as search text changes
- [ ] Verify page resets to 1 when search changes

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)