### PR TITLE
fix: reduce AI assistant verbosity

### DIFF
--- a/src/Nutrir.Infrastructure/Services/AiAgentService.cs
+++ b/src/Nutrir.Infrastructure/Services/AiAgentService.cs
@@ -90,14 +90,17 @@ public class AiAgentService : IAiAgentService
         - There is no undo/rollback capability. Inform the user if they ask to undo something.
 
         ## Response Guidelines
-        - Be concise and professional
+        - Be extremely concise. One sentence to confirm an action is better than three.
+        - Do NOT narrate your tool usage. Never say "Let me look up...", "I'll search for...", "Now I'll...", "Perfect, I found...", or similar. Tool lookups are invisible to the user — go straight to the answer or result.
+        - For write operations: briefly state what you'll do, then after the tool executes, confirm what was done. For follow-up requests in the same conversation, skip the intent and just confirm the result.
+        - Only explain intermediate steps when user input is needed (ambiguous results, missing required fields).
         - Format data in readable markdown tables or lists when showing multiple items
         - Include entity IDs for reference (e.g., "Client #3 - Maria Santos")
         - If results are empty, say so clearly ("No appointments found for today")
         - When showing appointments, include date, time, client name, type, and status
         - When showing clients, include name, email, and consent status
         - Round nutritional values to whole numbers
-        - For multi-step lookups (e.g., "Tell me about Maria Santos"), use the search tool first, then get details with the specific ID
+        - For multi-step lookups (e.g., "Tell me about Maria Santos"), use the search tool first, then get details with the specific ID — but do not narrate these steps to the user
         - After a successful write operation, briefly confirm what was done (e.g., "Client #12 - Sarah Johnson has been created.")
 
         ## Entity References


### PR DESCRIPTION
## Summary

- Updated the AI assistant's system prompt Response Guidelines to explicitly instruct the model to stop narrating tool usage steps
- Added instructions for concise follow-up responses and silent multi-step lookups
- Changed 4 guidelines in `BuildSystemPrompt()` in `AiAgentService.cs`

Closes #175

## Changes

| Before | After |
|--------|-------|
| "Be concise and professional" | "Be extremely concise. One sentence to confirm an action is better than three." |
| No mention of tool narration | Explicit "Do NOT narrate your tool usage" with examples of banned phrases |
| No follow-up guidance | "For follow-up requests, skip the intent and just confirm the result" |
| "use the search tool first, then get details" | Same, but adds "do not narrate these steps to the user" |

## Test plan

- [ ] Send a multi-step request (e.g., "Transfer X to me") and verify the assistant doesn't narrate lookups
- [ ] Send a follow-up request and verify it skips the intent statement
- [ ] Verify ambiguous searches still prompt for clarification
- [ ] Verify error cases still get explained

🤖 Generated with [Claude Code](https://claude.com/claude-code)