### PR TITLE
fix: preserve client fields during AI Assistant partial updates

### DIFF
--- a/src/Nutrir.Infrastructure/Services/AiToolExecutor.cs
+++ b/src/Nutrir.Infrastructure/Services/AiToolExecutor.cs
@@ -1485,23 +1485,28 @@ public class AiToolExecutor
     private async Task<string> HandleUpdateClient(JsonElement input)
     {
         var id = GetRequiredInt(input, "id");
+
+        var existing = await _clientService.GetByIdAsync(id);
+        if (existing is null)
+            return JsonSerializer.Serialize(new { error = $"Client #{id} not found" });
+
         var dto = new ClientDto(
             Id: id,
             FirstName: GetRequiredString(input, "first_name"),
             LastName: GetRequiredString(input, "last_name"),
-            Email: GetOptionalString(input, "email"),
-            Phone: GetOptionalString(input, "phone"),
-            DateOfBirth: GetOptionalDateOnly(input, "date_of_birth"),
+            Email: input.TryGetProperty("email", out _) ? GetOptionalString(input, "email") : existing.Email,
+            Phone: input.TryGetProperty("phone", out _) ? GetOptionalString(input, "phone") : existing.Phone,
+            DateOfBirth: input.TryGetProperty("date_of_birth", out _) ? GetOptionalDateOnly(input, "date_of_birth") : existing.DateOfBirth,
             PrimaryNutritionistId: GetRequiredString(input, "primary_nutritionist_id"),
-            PrimaryNutritionistName: null,
-            ConsentGiven: false,
-            ConsentTimestamp: null,
-            ConsentPolicyVersion: null,
-            Notes: GetOptionalString(input, "notes"),
-            IsDeleted: false,
-            CreatedAt: DateTime.UtcNow,
-            UpdatedAt: null,
-            DeletedAt: null);
+            PrimaryNutritionistName: existing.PrimaryNutritionistName,
+            ConsentGiven: existing.ConsentGiven,
+            ConsentTimestamp: existing.ConsentTimestamp,
+            ConsentPolicyVersion: existing.ConsentPolicyVersion,
+            Notes: input.TryGetProperty("notes", out _) ? GetOptionalString(input, "notes") : existing.Notes,
+            IsDeleted: existing.IsDeleted,
+            CreatedAt: existing.CreatedAt,
+            UpdatedAt: DateTime.UtcNow,
+            DeletedAt: existing.DeletedAt);
 
         var success = await _clientService.UpdateAsync(id, dto, _currentUserId ?? "system");
         return success


### PR DESCRIPTION
## Summary

- Fixed data loss bug where AI Assistant's `update_client` tool wiped optional client fields (email, phone, DOB, notes) when only changing specific fields like primary nutritionist
- Now fetches the existing client before building the update DTO, merging only fields explicitly provided by the LLM via `TryGetProperty` checks
- Also fixes: `CreatedAt` no longer overwritten, consent fields preserved, `IsDeleted`/`DeletedAt` preserved

## Root Cause

`HandleUpdateClient` constructed a `ClientDto` using `GetOptionalString()` for optional fields, which returned `null` when the AI didn't include them. `ClientService.UpdateAsync` then overwrote those fields with `null` via direct assignment.

## Changes

**`AiToolExecutor.cs` — `HandleUpdateClient`:**
- Fetch existing client via `GetByIdAsync` before constructing DTO
- Use `input.TryGetProperty()` to detect which fields the AI actually sent
- Fall back to existing values for any field not in the AI input
- Preserve consent, timestamp, and deletion fields from existing record

Closes #174

## Test Plan

- [ ] Update a client's nutritionist via AI Assistant → verify email, phone, DOB, notes unchanged
- [ ] Update a client's name via AI Assistant → verify other fields unchanged
- [ ] Update a client's email via AI Assistant → verify it actually changes
- [ ] Verify non-existent client ID returns proper error

🤖 Generated with [Claude Code](https://claude.com/claude-code)