### PR TITLE
feat: add custom APM spans for observability

### DIFF
--- a/src/Nutrir.Infrastructure/Diagnostics/NutrirTelemetry.cs
+++ b/src/Nutrir.Infrastructure/Diagnostics/NutrirTelemetry.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics;
+
+namespace Nutrir.Infrastructure.Diagnostics;
+
+/// <summary>
+/// Centralized ActivitySource definitions for custom APM spans.
+/// Elastic APM (1.26+) automatically bridges System.Diagnostics.Activity to APM spans.
+/// </summary>
+public static class NutrirTelemetry
+{
+    public const string ServiceName = "Nutrir";
+
+    /// <summary>AI assistant operations: conversations, API calls, tool execution.</summary>
+    public static readonly ActivitySource AiSource = new($"{ServiceName}.AI");
+
+    /// <summary>Domain service operations: CRUD, search, dashboard, reports.</summary>
+    public static readonly ActivitySource AppSource = new($"{ServiceName}.App");
+
+    /// <summary>Document generation: PDF, DOCX rendering.</summary>
+    public static readonly ActivitySource DocSource = new($"{ServiceName}.Documents");
+}

--- a/src/Nutrir.Infrastructure/Services/AiAgentService.cs
+++ b/src/Nutrir.Infrastructure/Services/AiAgentService.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using Nutrir.Core.Enums;
 using Nutrir.Core.Interfaces;
 using Nutrir.Infrastructure.Configuration;
+using Nutrir.Infrastructure.Diagnostics;
 
 namespace Nutrir.Infrastructure.Services;
 
@@ -160,6 +161,10 @@ public class AiAgentService : IAiAgentService
         string userMessage,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        using var conversationActivity = NutrirTelemetry.AiSource.StartActivity("AI Conversation");
+        conversationActivity?.SetTag("ai.user_id", _userId);
+        conversationActivity?.SetTag("ai.model", _options.Model);
+
         if (string.IsNullOrWhiteSpace(_options.ApiKey))
         {
             yield return new AgentStreamEvent { Error = "Anthropic API key is not configured. Please set the API key in user secrets or environment variables." };
@@ -172,6 +177,7 @@ public class AiAgentService : IAiAgentService
             var (allowed, rateLimitMessage) = _rateLimiter.CheckAndRecord(_userId);
             if (!allowed)
             {
+                conversationActivity?.SetTag("ai.rate_limited", true);
                 yield return new AgentStreamEvent { Error = rateLimitMessage };
                 yield break;
             }
@@ -228,7 +234,20 @@ public class AiAgentService : IAiAgentService
             }
 
             // Stream the response, collecting content blocks and yielding text deltas
-            var result = await StreamAndCollectAsync(client, parameters, cancellationToken);
+            StreamResult result;
+            using (var apiActivity = NutrirTelemetry.AiSource.StartActivity("Anthropic API Call"))
+            {
+                apiActivity?.SetTag("ai.model", _options.Model);
+                apiActivity?.SetTag("ai.iteration", iteration);
+
+                result = await StreamAndCollectAsync(client, parameters, cancellationToken);
+
+                apiActivity?.SetTag("ai.input_tokens", result.InputTokens);
+                apiActivity?.SetTag("ai.output_tokens", result.OutputTokens);
+                apiActivity?.SetTag("ai.stop_reason", result.StopReason?.ToString());
+                if (result.Error is not null)
+                    apiActivity?.SetStatus(ActivityStatusCode.Error, result.Error);
+            }
 
             totalInputTokens += result.InputTokens;
             totalOutputTokens += result.OutputTokens;
@@ -360,10 +379,19 @@ public class AiAgentService : IAiAgentService
             }
 
             // end_turn or max_tokens — done
+            conversationActivity?.SetTag("ai.total_input_tokens", totalInputTokens);
+            conversationActivity?.SetTag("ai.total_output_tokens", totalOutputTokens);
+            conversationActivity?.SetTag("ai.total_tool_calls", totalToolCalls);
+
             yield return new AgentStreamEvent { IsComplete = true };
             await SaveAndLogAsync(newMessages, displayTexts, totalInputTokens, totalOutputTokens, totalToolCalls, overallStopwatch);
             yield break;
         }
+
+        conversationActivity?.SetTag("ai.total_input_tokens", totalInputTokens);
+        conversationActivity?.SetTag("ai.total_output_tokens", totalOutputTokens);
+        conversationActivity?.SetTag("ai.total_tool_calls", totalToolCalls);
+        conversationActivity?.SetStatus(ActivityStatusCode.Error, "Max tool iterations reached");
 
         yield return new AgentStreamEvent { Error = "Maximum tool call iterations reached. Please try a simpler question." };
         await SaveAndLogAsync(newMessages, displayTexts, totalInputTokens, totalOutputTokens, totalToolCalls, overallStopwatch);

--- a/src/Nutrir.Infrastructure/Services/AiConversationStore.cs
+++ b/src/Nutrir.Infrastructure/Services/AiConversationStore.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Nutrir.Core.Entities;
 using Nutrir.Core.Interfaces;
 using Nutrir.Infrastructure.Data;
+using Nutrir.Infrastructure.Diagnostics;
 
 namespace Nutrir.Infrastructure.Services;
 
@@ -23,6 +24,9 @@ public class AiConversationStore : IAiConversationStore
 
     public async Task<ConversationSnapshot?> LoadActiveSessionAsync(string userId)
     {
+        using var activity = NutrirTelemetry.AiSource.StartActivity("AI LoadConversation");
+        activity?.SetTag("ai.user_id", userId);
+
         await using var db = await _dbContextFactory.CreateDbContextAsync();
         var cutoff = DateTime.UtcNow - SessionExpiry;
 
@@ -67,6 +71,10 @@ public class AiConversationStore : IAiConversationStore
     {
         if (newMessages.Count == 0)
             return;
+
+        using var activity = NutrirTelemetry.AiSource.StartActivity("AI SaveMessages");
+        activity?.SetTag("ai.user_id", userId);
+        activity?.SetTag("ai.message_count", newMessages.Count);
 
         await using var db = await _dbContextFactory.CreateDbContextAsync();
         var cutoff = DateTime.UtcNow - SessionExpiry;

--- a/src/Nutrir.Infrastructure/Services/AiToolExecutor.cs
+++ b/src/Nutrir.Infrastructure/Services/AiToolExecutor.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using Anthropic.Models.Messages;
@@ -5,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Nutrir.Core.DTOs;
 using Nutrir.Core.Enums;
 using Nutrir.Core.Interfaces;
+using Nutrir.Infrastructure.Diagnostics;
 
 namespace Nutrir.Infrastructure.Services;
 
@@ -742,6 +744,11 @@ public class AiToolExecutor
 
     public async Task<string> ExecuteAsync(string toolName, IReadOnlyDictionary<string, JsonElement> input, string? userId = null)
     {
+        using var activity = NutrirTelemetry.AiSource.StartActivity($"Tool: {toolName}");
+        activity?.SetTag("ai.tool.name", toolName);
+        activity?.SetTag("ai.tool.user_id", userId);
+        activity?.SetTag("ai.tool.is_write", ConfirmationTierMap.ContainsKey(toolName));
+
         _currentUserId = userId;
 
         // Convert dictionary to JsonElement for handler convenience
@@ -751,15 +758,19 @@ public class AiToolExecutor
         {
             try
             {
-                return await handler(jsonElement);
+                var result = await handler(jsonElement);
+                activity?.SetStatus(ActivityStatusCode.Ok);
+                return result;
             }
             catch (Exception ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 _logger.LogError(ex, "Error executing tool {ToolName}", toolName);
                 return JsonSerializer.Serialize(new { error = $"Error executing {toolName}: {ex.Message}" });
             }
         }
 
+        activity?.SetStatus(ActivityStatusCode.Error, "Unknown tool");
         return JsonSerializer.Serialize(new { error = $"Unknown tool: {toolName}" });
     }
 

--- a/src/Nutrir.Infrastructure/Services/ConsentFormService.cs
+++ b/src/Nutrir.Infrastructure/Services/ConsentFormService.cs
@@ -7,6 +7,7 @@ using Nutrir.Core.Enums;
 using Nutrir.Core.Interfaces;
 using Nutrir.Infrastructure.Configuration;
 using Nutrir.Infrastructure.Data;
+using Nutrir.Infrastructure.Diagnostics;
 
 namespace Nutrir.Infrastructure.Services;
 
@@ -37,6 +38,11 @@ public class ConsentFormService : IConsentFormService
 
     public async Task<byte[]> GeneratePdfAsync(int clientId, string userId)
     {
+        using var activity = NutrirTelemetry.DocSource.StartActivity("ConsentForm PDF Generation");
+        activity?.SetTag("document.type", "pdf");
+        activity?.SetTag("document.entity_type", "ConsentForm");
+        activity?.SetTag("document.client_id", clientId);
+
         var (client, practitionerName) = await GetClientAndPractitionerAsync(clientId);
         var clientName = $"{client.FirstName} {client.LastName}";
         var content = _template.Generate(clientName, practitionerName, DateTime.UtcNow);
@@ -58,6 +64,11 @@ public class ConsentFormService : IConsentFormService
 
     public async Task<byte[]> GenerateDocxAsync(int clientId, string userId)
     {
+        using var activity = NutrirTelemetry.DocSource.StartActivity("ConsentForm DOCX Generation");
+        activity?.SetTag("document.type", "docx");
+        activity?.SetTag("document.entity_type", "ConsentForm");
+        activity?.SetTag("document.client_id", clientId);
+
         var (client, practitionerName) = await GetClientAndPractitionerAsync(clientId);
         var clientName = $"{client.FirstName} {client.LastName}";
         var content = _template.Generate(clientName, practitionerName, DateTime.UtcNow);

--- a/src/Nutrir.Infrastructure/Services/DashboardService.cs
+++ b/src/Nutrir.Infrastructure/Services/DashboardService.cs
@@ -4,6 +4,7 @@ using Nutrir.Core.Entities;
 using Nutrir.Core.Enums;
 using Nutrir.Core.Interfaces;
 using Nutrir.Infrastructure.Data;
+using Nutrir.Infrastructure.Diagnostics;
 
 namespace Nutrir.Infrastructure.Services;
 
@@ -20,6 +21,7 @@ public class DashboardService : IDashboardService
 
     public async Task<DashboardMetricsDto> GetMetricsAsync()
     {
+        using var activity = NutrirTelemetry.AppSource.StartActivity("Dashboard GetMetrics");
         await using var db = await _dbContextFactory.CreateDbContextAsync();
         var now = DateTime.UtcNow;
         var startOfMonth = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -53,6 +55,7 @@ public class DashboardService : IDashboardService
 
     public async Task<List<AppointmentDto>> GetTodaysAppointmentsAsync()
     {
+        using var activity = NutrirTelemetry.AppSource.StartActivity("Dashboard TodaysAppointments");
         await using var db = await _dbContextFactory.CreateDbContextAsync();
         var today = DateTime.UtcNow.Date;
         var tomorrow = today.AddDays(1);
@@ -110,6 +113,7 @@ public class DashboardService : IDashboardService
 
     public async Task<List<MealPlanSummaryDto>> GetRecentMealPlansAsync(int count = 5)
     {
+        using var activity = NutrirTelemetry.AppSource.StartActivity("Dashboard RecentMealPlans");
         await using var db = await _dbContextFactory.CreateDbContextAsync();
 
         var entities = await db.MealPlans

--- a/src/Nutrir.Infrastructure/Services/MealPlanPdfService.cs
+++ b/src/Nutrir.Infrastructure/Services/MealPlanPdfService.cs
@@ -1,4 +1,5 @@
 using Nutrir.Core.Interfaces;
+using Nutrir.Infrastructure.Diagnostics;
 
 namespace Nutrir.Infrastructure.Services;
 
@@ -15,11 +16,17 @@ public class MealPlanPdfService : IMealPlanPdfService
 
     public async Task<byte[]> GeneratePdfAsync(int mealPlanId, string userId)
     {
+        using var activity = NutrirTelemetry.DocSource.StartActivity("MealPlan PDF Generation");
+        activity?.SetTag("document.type", "pdf");
+        activity?.SetTag("document.entity_type", "MealPlan");
+        activity?.SetTag("document.entity_id", mealPlanId);
+
         var plan = await _mealPlanService.GetByIdAsync(mealPlanId);
         if (plan is null)
             throw new KeyNotFoundException($"Meal plan #{mealPlanId} not found.");
 
         var pdfBytes = MealPlanPdfRenderer.Render(plan);
+        activity?.SetTag("document.size_bytes", pdfBytes.Length);
 
         await _auditLogService.LogAsync(
             userId,

--- a/src/Nutrir.Infrastructure/Services/ReportService.cs
+++ b/src/Nutrir.Infrastructure/Services/ReportService.cs
@@ -4,6 +4,7 @@ using Nutrir.Core.DTOs;
 using Nutrir.Core.Enums;
 using Nutrir.Core.Interfaces;
 using Nutrir.Infrastructure.Data;
+using Nutrir.Infrastructure.Diagnostics;
 
 namespace Nutrir.Infrastructure.Services;
 
@@ -20,6 +21,11 @@ public class ReportService : IReportService
 
     public async Task<PracticeSummaryDto> GetPracticeSummaryAsync(DateTime startDate, DateTime endDate)
     {
+        using var activity = NutrirTelemetry.AppSource.StartActivity("Report PracticeSummary");
+        activity?.SetTag("report.start_date", startDate.ToString("O"));
+        activity?.SetTag("report.end_date", endDate.ToString("O"));
+        activity?.SetTag("report.range_days", (endDate - startDate).TotalDays);
+
         await using var db = await _dbContextFactory.CreateDbContextAsync();
 
         var appointments = await db.Appointments

--- a/src/Nutrir.Infrastructure/Services/SearchService.cs
+++ b/src/Nutrir.Infrastructure/Services/SearchService.cs
@@ -3,6 +3,7 @@ using Nutrir.Core.DTOs;
 using Nutrir.Core.Enums;
 using Nutrir.Core.Interfaces;
 using Nutrir.Infrastructure.Data;
+using Nutrir.Infrastructure.Diagnostics;
 
 namespace Nutrir.Infrastructure.Services;
 
@@ -12,6 +13,9 @@ public class SearchService(AppDbContext dbContext) : ISearchService
     {
         if (string.IsNullOrWhiteSpace(query) || query.Trim().Length < 2)
             return new SearchResultDto([], 0);
+
+        using var activity = NutrirTelemetry.AppSource.StartActivity("Search");
+        activity?.SetTag("search.term_count", query.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries).Length);
 
         var terms = query.Trim().ToLower().Split(' ', StringSplitOptions.RemoveEmptyEntries);
         var groups = new List<SearchResultGroup>();
@@ -32,6 +36,8 @@ public class SearchService(AppDbContext dbContext) : ISearchService
             groups.Add(mealPlanGroup);
 
         var totalCount = groups.Sum(g => g.TotalInGroup);
+        activity?.SetTag("search.result_count", totalCount);
+        activity?.SetTag("search.group_count", groups.Count);
         return new SearchResultDto(groups, totalCount);
     }
 


### PR DESCRIPTION
## Summary
- Adds `System.Diagnostics.ActivitySource`-based custom APM spans across the application, filling the gap where only auto-instrumented HTTP/EF Core operations were visible
- Instruments the **AI assistant path** (conversations, Anthropic API calls, per-tool execution, conversation persistence) with rich tags (model, tokens, tool names, stop reasons)
- Instruments **domain services** (search, dashboard aggregations, practice reports) and **document generation** (meal plan PDF, consent form PDF/DOCX)
- Vendor-neutral approach — auto-bridged by Elastic APM 1.30+, also compatible with OpenTelemetry

## Test plan
- [ ] Verify the app builds and starts without errors
- [ ] Send a message via the AI assistant and confirm spans appear in Elastic APM (or Seq log correlation)
- [ ] Confirm `AI Conversation`, `Anthropic API Call`, and `Tool: {name}` spans nest correctly under the parent HTTP transaction
- [ ] Navigate to the dashboard and verify `Dashboard GetMetrics` / `Dashboard TodaysAppointments` spans appear
- [ ] Run a search and confirm `Search` span with result count tags
- [ ] Export a meal plan PDF and confirm `MealPlan PDF Generation` span with `document.size_bytes`
- [ ] Generate a consent form and confirm `ConsentForm PDF Generation` / `ConsentForm DOCX Generation` spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)