### PR TITLE
Redesign meal plan edit-details page

### DIFF
--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor
@@ -8,6 +8,7 @@
 @using Nutrir.Core.DTOs
 @using Nutrir.Core.Enums
 @using Nutrir.Core.Interfaces
+@using Nutrir.Web.Components.UI
 @attribute [Authorize(Roles = "Admin,Nutritionist,Assistant")]
 @inject IMealPlanService MealPlanService
 @inject IClientService ClientService
@@ -15,28 +16,34 @@
 
 <PageTitle>Edit Meal Plan Details — Nutrir</PageTitle>
 
-<div class="form-page">
-    <div class="page-header">
-        <a href="/meal-plans/@Id" class="back-link">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="m15 18-6-6 6-6"/>
-            </svg>
-        </a>
-        <h1 class="page-title">Edit Meal Plan Details</h1>
-    </div>
+<Breadcrumb Items="@(new[] { new BreadcrumbItem("Meal Plans", "/meal-plans"), new BreadcrumbItem(_plan?.Title ?? "Meal Plan", $"/meal-plans/{Id}"), new BreadcrumbItem("Edit Details") })" />
 
+<div class="md-edit-page">
     @if (_isLoading)
     {
-        <p>Loading...</p>
+        <div class="md-loading">
+            <div class="md-spinner"></div>
+            <span>Loading meal plan details...</span>
+        </div>
     }
     else if (_notFound)
     {
         <div class="table-card">
-            <div class="error-banner">Meal plan not found.</div>
+            <div class="md-not-found">
+                <p class="not-found-title">Meal plan not found</p>
+                <div class="not-found-action">
+                    <Button Variant="ButtonVariant.Outline" OnClick="@(() => NavigationManager.NavigateTo("/meal-plans"))">Back to Meal Plans</Button>
+                </div>
+            </div>
         </div>
     }
     else
     {
+        <div class="page-header">
+            <h1 class="page-title">@_plan!.Title</h1>
+            <Badge Variant="@GetStatusVariant(_plan.Status)">@_plan.Status</Badge>
+        </div>
+
         <div class="table-card">
             <EditForm Model="_model" OnValidSubmit="HandleSubmit" FormName="EditMealPlanMetadata">
                 <DataAnnotationsValidator />
@@ -74,7 +81,7 @@
 
                         <FormGroup Label="Description" Id="description">
                             <textarea id="description"
-                                      class="form-input"
+                                      class="form-textarea"
                                       rows="2"
                                       @bind="_model.Description"
                                       placeholder="Overview or goals..."></textarea>
@@ -165,7 +172,7 @@
                     <div class="form-body">
                         <FormGroup Label="Internal Notes" Id="notes">
                             <textarea id="notes"
-                                      class="form-input"
+                                      class="form-textarea"
                                       rows="2"
                                       @bind="_model.Notes"
                                       placeholder="Practitioner notes..."></textarea>
@@ -173,7 +180,7 @@
 
                         <FormGroup Label="Client Instructions" Id="instructions">
                             <textarea id="instructions"
-                                      class="form-input"
+                                      class="form-textarea"
                                       rows="2"
                                       @bind="_model.Instructions"
                                       placeholder="Instructions for the client..."></textarea>
@@ -211,6 +218,7 @@
     [Parameter] public int Id { get; set; }
     [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
 
+    private MealPlanDetailDto? _plan;
     private MealPlanFormModel _model = new();
     private EditContext? _editContext;
     private List<ClientDto> _clients = [];
@@ -227,32 +235,32 @@
         _editContext = new EditContext(_model);
         _clients = await ClientService.GetListAsync();
 
-        var plan = await MealPlanService.GetByIdAsync(Id);
-        if (plan is null)
+        _plan = await MealPlanService.GetByIdAsync(Id);
+        if (_plan is null)
         {
             _notFound = true;
             _isLoading = false;
             return;
         }
 
-        if (plan.Status is MealPlanStatus.Archived)
+        if (_plan.Status is MealPlanStatus.Archived)
         {
             NavigationManager.NavigateTo($"/meal-plans/{Id}");
             return;
         }
 
-        _model.ClientId = plan.ClientId.ToString();
-        _model.Title = plan.Title;
-        _model.Description = plan.Description;
-        _model.StartDate = plan.StartDate?.ToString("yyyy-MM-dd");
-        _model.EndDate = plan.EndDate?.ToString("yyyy-MM-dd");
-        _model.NumberOfDays = plan.Days.Count > 0 ? plan.Days.Count.ToString() : "7";
-        _model.CalorieTarget = plan.CalorieTarget?.ToString();
-        _model.ProteinTarget = plan.ProteinTargetG?.ToString();
-        _model.CarbsTarget = plan.CarbsTargetG?.ToString();
-        _model.FatTarget = plan.FatTargetG?.ToString();
-        _model.Notes = plan.Notes;
-        _model.Instructions = plan.Instructions;
+        _model.ClientId = _plan.ClientId.ToString();
+        _model.Title = _plan.Title;
+        _model.Description = _plan.Description;
+        _model.StartDate = _plan.StartDate?.ToString("yyyy-MM-dd");
+        _model.EndDate = _plan.EndDate?.ToString("yyyy-MM-dd");
+        _model.NumberOfDays = _plan.Days.Count > 0 ? _plan.Days.Count.ToString() : "7";
+        _model.CalorieTarget = _plan.CalorieTarget?.ToString();
+        _model.ProteinTarget = _plan.ProteinTargetG?.ToString();
+        _model.CarbsTarget = _plan.CarbsTargetG?.ToString();
+        _model.FatTarget = _plan.FatTargetG?.ToString();
+        _model.Notes = _plan.Notes;
+        _model.Instructions = _plan.Instructions;
 
         _isLoading = false;
     }
@@ -346,6 +354,14 @@
         var messages = _editContext.GetValidationMessages(new FieldIdentifier(_model, fieldName));
         return messages.FirstOrDefault();
     }
+
+    private static BadgeVariant GetStatusVariant(MealPlanStatus status) => status switch
+    {
+        MealPlanStatus.Draft => BadgeVariant.Secondary,
+        MealPlanStatus.Active => BadgeVariant.Success,
+        MealPlanStatus.Archived => BadgeVariant.Accent,
+        _ => BadgeVariant.Primary
+    };
 
     private class MealPlanFormModel
     {

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor.css
@@ -1,0 +1,219 @@
+/* ── Page Container ───────────────────────────────────── */
+.md-edit-page {
+    max-width: 720px;
+    padding: var(--space-8);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+
+/* ── Page Header ──────────────────────────────────────── */
+.page-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-2);
+}
+
+.page-title {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+/* ── Loading State ────────────────────────────────────── */
+.md-loading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-8);
+    justify-content: center;
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
+}
+
+.md-spinner {
+    width: 20px;
+    height: 20px;
+    border: 2px solid var(--color-border);
+    border-top-color: var(--color-primary);
+    border-radius: var(--radius-full);
+    animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+/* ── Not Found ────────────────────────────────────────── */
+.table-card {
+    background: var(--color-bg-card);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--color-border);
+    overflow: hidden;
+}
+
+.md-not-found {
+    padding: var(--space-16) var(--space-6);
+    text-align: center;
+}
+
+.not-found-title {
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: var(--space-2);
+}
+
+.not-found-action {
+    display: flex;
+    justify-content: center;
+    margin-top: var(--space-4);
+}
+
+/* ── Section Header ───────────────────────────────────── */
+.section-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-6);
+    background: var(--color-bg-alt);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    user-select: none;
+    transition: background var(--duration-fast) var(--ease-default);
+}
+
+.section-header:hover {
+    background: color-mix(in srgb, var(--color-bg-alt) 80%, var(--color-primary-muted));
+}
+
+.section-header svg {
+    flex-shrink: 0;
+    opacity: 0.7;
+}
+
+/* ── Section Chevron ──────────────────────────────────── */
+.section-chevron {
+    margin-left: auto;
+    transition: transform var(--duration-fast) var(--ease-default);
+}
+
+.section-chevron.collapsed {
+    transform: rotate(-90deg);
+}
+
+/* Add top border between sections */
+.form-body + .section-header {
+    border-top: 1px solid var(--color-border);
+}
+
+/* ── Form Body ────────────────────────────────────────── */
+.form-body {
+    padding: var(--space-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+}
+
+/* ── Form Grid ────────────────────────────────────────── */
+.form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-4);
+}
+
+/* ── Error Banner ─────────────────────────────────────── */
+.error-banner {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-6);
+    background: color-mix(in srgb, var(--color-error) 8%, transparent);
+    border-top: 1px solid color-mix(in srgb, var(--color-error) 30%, var(--color-border));
+    font-size: var(--text-sm);
+    color: var(--color-error);
+}
+
+.error-banner svg {
+    flex-shrink: 0;
+}
+
+/* ── Form Actions ─────────────────────────────────────── */
+.form-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-4) var(--space-6);
+    border-top: 1px solid var(--color-border);
+    background: var(--color-bg-alt);
+}
+
+.cancel-link {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-default);
+}
+
+.cancel-link:hover {
+    color: var(--color-text);
+    text-decoration: underline;
+}
+
+/* ── Entrance Animation ──────────────────────────────── */
+@keyframes cardFadeIn {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+.table-card {
+    animation: cardFadeIn 0.3s var(--ease-default) backwards;
+    animation-delay: 0.05s;
+}
+
+/* ── Responsive ───────────────────────────────────────── */
+@media (max-width: 600px) {
+    .md-edit-page {
+        padding: var(--space-4);
+    }
+
+    .form-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .section-header {
+        padding: var(--space-3) var(--space-4);
+    }
+
+    .form-body {
+        padding: var(--space-4);
+    }
+
+    .form-actions {
+        padding: var(--space-4);
+    }
+}
+
+/* ── Reduced Motion ───────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+    .table-card {
+        animation: none;
+    }
+
+    .md-spinner {
+        animation-duration: 1.5s;
+    }
+
+    .section-chevron {
+        transition: none;
+    }
+}


### PR DESCRIPTION
## Summary
- Added `<Breadcrumb>` navigation (`Meal Plans > {Title} > Edit Details`) and page header with title + status `<Badge>`, matching the sibling `MealPlanEdit.razor` page
- Replaced plain "Loading..." text with a CSS spinner, upgraded not-found state to a centered card with back button, and changed `<textarea>` elements to use the design system's `form-textarea` class
- Created scoped `MealPlanMetadataEdit.razor.css` with entrance animation, responsive breakpoints, and `prefers-reduced-motion` support

## Test plan
- [ ] Navigate to `/meal-plans/{id}/edit-details` and verify breadcrumb shows `Meal Plans > {Plan Title} > Edit Details`
- [ ] Verify page header displays plan title with correct status badge (Draft/Active)
- [ ] Confirm loading spinner appears briefly on page load
- [ ] Test all three collapsible sections expand/collapse correctly
- [ ] Submit the form and verify save + redirect works
- [ ] Verify archived plans still redirect to detail page
- [ ] Navigate to a non-existent meal plan ID and verify not-found card with back button
- [ ] Test responsive layout at mobile widths (< 600px) — form grid should collapse to single column
- [ ] Verify textarea fields (Description, Notes, Instructions) render with correct styling

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)