### PR TITLE
Center .form-page containers on all form pages

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Appointments/AppointmentCreate.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Appointments/AppointmentCreate.razor.css
@@ -1,6 +1,7 @@
 /* ── Page Container ───────────────────────────────────── */
 .form-page {
     max-width: 720px;
+    margin: 0 auto;
     padding: var(--space-8);
 }
 

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor.css
@@ -1,6 +1,7 @@
 /* ── Page Container ───────────────────────────────────── */
 .form-page {
     max-width: 960px;
+    margin: 0 auto;
     padding: var(--space-8);
 }
 

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor.css
@@ -1,6 +1,7 @@
 /* ── Page Container ───────────────────────────────────── */
 .form-page {
     max-width: 960px;
+    margin: 0 auto;
     padding: var(--space-8);
 }
 

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanCreate.razor.css
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanCreate.razor.css
@@ -1,6 +1,7 @@
 /* ── Page Container ───────────────────────────────────── */
 .form-page {
     max-width: 720px;
+    margin: 0 auto;
     padding: var(--space-8);
 }
 

--- a/src/Nutrir.Web/Components/Pages/Progress/ProgressEntryCreate.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Progress/ProgressEntryCreate.razor.css
@@ -1,6 +1,7 @@
 /* ── Page Container ───────────────────────────────────── */
 .form-page {
     max-width: 720px;
+    margin: 0 auto;
     padding: var(--space-8);
 }
 

--- a/src/Nutrir.Web/Components/Pages/Progress/ProgressEntryEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Progress/ProgressEntryEdit.razor.css
@@ -1,6 +1,7 @@
 /* ── Page Container ───────────────────────────────────── */
 .form-page {
     max-width: 720px;
+    margin: 0 auto;
     padding: var(--space-8);
 }
 

--- a/src/Nutrir.Web/Components/Pages/Settings/AvailabilitySettings.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Settings/AvailabilitySettings.razor.css
@@ -1,6 +1,7 @@
 /* ── Page Container ───────────────────────────────────── */
 .form-page {
     max-width: 720px;
+    margin: 0 auto;
     padding: var(--space-8);
 }
 


### PR DESCRIPTION
## Summary
- Add `margin: 0 auto` to `.form-page` in all 7 component CSS files so form pages are horizontally centered within the main content area
- The issue reported ClientEdit specifically, but all form pages had the same missing centering — fixed consistently across the board

### Files changed
- `ClientEdit.razor.css` (reported in issue)
- `ClientCreate.razor.css`
- `AppointmentCreate.razor.css`
- `AvailabilitySettings.razor.css`
- `ProgressEntryEdit.razor.css`
- `ProgressEntryCreate.razor.css`
- `MealPlanCreate.razor.css`

Closes #198

## Test plan
- [ ] Verify `/clients/{id}/edit` page is horizontally centered
- [ ] Verify no regressions on mobile (≤600px) — padding still applies, margin auto is harmless at full-width
- [ ] Spot-check other form pages (client create, appointment create, etc.) for consistent centering

🤖 Generated with [Claude Code](https://claude.com/claude-code)