### PR TITLE
Fix cramped consent status layout on client edit page

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor.css
@@ -175,7 +175,20 @@
 
 /* ── Consent Row ──────────────────────────────────────── */
 .consent-row {
-    padding: var(--space-2) 0;
+    padding: var(--space-4) 0;
+    border-top: 1px solid var(--color-border);
+}
+
+.consent-status {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+}
+
+.consent-meta {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
 }
 
 /* ── Error Banner ─────────────────────────────────────── */
@@ -304,5 +317,9 @@
 
     .form-actions {
         padding: var(--space-4);
+    }
+
+    .consent-status {
+        gap: var(--space-2);
     }
 }


### PR DESCRIPTION
## Summary
- Added flexbox layout with `gap` to `.consent-status` for proper spacing between badge, date stamp, and withdraw button
- Added `.consent-meta` styling with appropriate font size and muted color
- Increased `.consent-row` padding and added a top border separator
- Added responsive `gap` reduction for narrow viewports

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)