### PR TITLE
Enhance upcoming appointments widget: add link and nutritionist name

### DIFF
--- a/src/Nutrir.Web/Components/Widgets/UpcomingAppointmentsWidget.razor
+++ b/src/Nutrir.Web/Components/Widgets/UpcomingAppointmentsWidget.razor
@@ -44,7 +44,7 @@
                     };
 
                     <div class="appointment-card">
-                        <div class="appointment-main">
+                        <a class="appointment-card-link" href="/appointments/@appt.Id/edit">
                             <div class="appointment-datetime">
                                 <span class="appointment-date">@localStart.ToString("ddd, MMM d")</span>
                                 <span class="appointment-time-sep">&middot;</span>
@@ -74,8 +74,12 @@
                                     }
                                 </span>
                                 <span class="appointment-duration">@appt.DurationMinutes min</span>
+                                @if (!string.IsNullOrEmpty(appt.NutritionistName))
+                                {
+                                    <span class="appointment-nutritionist">with @appt.NutritionistName</span>
+                                }
                             </div>
-                        </div>
+                        </a>
                         <div class="appointment-actions">
                             @if (_cancellingId == appt.Id)
                             {

--- a/src/Nutrir.Web/Components/Widgets/UpcomingAppointmentsWidget.razor.css
+++ b/src/Nutrir.Web/Components/Widgets/UpcomingAppointmentsWidget.razor.css
@@ -41,12 +41,20 @@
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
 }
 
-.appointment-main {
+.appointment-card-link {
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
     min-width: 0;
     flex: 1;
+    text-decoration: none;
+    color: inherit;
+}
+
+.appointment-card-link:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
 }
 
 .appointment-datetime {
@@ -104,6 +112,11 @@
 
 .appointment-duration {
     white-space: nowrap;
+}
+
+.appointment-nutritionist {
+    white-space: nowrap;
+    font-style: italic;
 }
 
 .appointment-actions {


### PR DESCRIPTION
## Summary

- Wrapped appointment card content in a clickable `<a>` link to `/appointments/{id}/edit` for quick navigation
- Added nutritionist name display ("with Dr. Smith") in the appointment details section
- Added `:focus-visible` style for keyboard accessibility on the card link

Closes #200

## Test plan

- [ ] Navigate to a client detail page with upcoming appointments
- [ ] Verify each appointment card's main area is clickable and navigates to the appointment edit page
- [ ] Verify nutritionist name appears in the details row (italic, "with {name}")
- [ ] Verify appointments without a nutritionist name don't show the label
- [ ] Verify Reschedule/Cancel actions still work independently of the card link
- [ ] Verify keyboard navigation shows a focus ring on the card link

🤖 Generated with [Claude Code](https://claude.com/claude-code)