### PR TITLE
fix: hide OAuth placeholder and divider when no providers registered

### DIFF
--- a/src/Nutrir.Web/Components/Account/Pages/Login.razor
+++ b/src/Nutrir.Web/Components/Account/Pages/Login.razor
@@ -47,8 +47,6 @@
         </div>
     </EditForm>
 
-    <div class="divider-text mt-6 mb-6">or continue with</div>
-
     <ExternalLoginPicker />
 
     <div class="flex flex-col gap-2 mt-6 text-center">

--- a/src/Nutrir.Web/Components/Account/Pages/Register.razor
+++ b/src/Nutrir.Web/Components/Account/Pages/Register.razor
@@ -93,8 +93,6 @@
                 <button type="submit" class="btn btn-primary btn-lg btn-block">Register</button>
             </div>
 
-            <div class="divider-text mt-6 mb-6">or continue with</div>
-
             <ExternalLoginPicker />
 
             <div class="flex flex-col gap-2 mt-6 text-center">

--- a/src/Nutrir.Web/Components/Account/Shared/ExternalLoginPicker.razor
+++ b/src/Nutrir.Web/Components/Account/Shared/ExternalLoginPicker.razor
@@ -5,17 +5,10 @@
 @inject SignInManager<ApplicationUser> SignInManager
 @inject IdentityRedirectManager RedirectManager
 
-@if (externalLogins.Length == 0)
+@if (externalLogins.Length > 0)
 {
-    <div>
-        <p class="text-muted text-sm">
-            There are no external authentication services configured. See this <a href="https://go.microsoft.com/fwlink/?LinkID=532715">article
-            about setting up this ASP.NET application to support logging in via external services</a>.
-        </p>
-    </div>
-}
-else
-{
+    <div class="divider-text mt-6 mb-6">or continue with</div>
+
     <form action="Account/PerformExternalLogin" method="post">
         <AntiforgeryToken />
         <input type="hidden" name="ReturnUrl" value="@ReturnUrl" />


### PR DESCRIPTION
## Summary

- **ExternalLoginPicker**: Removed the scaffolded ASP.NET placeholder text (Microsoft docs link) shown when no OAuth providers are configured. Now renders nothing when `externalLogins.Length == 0`.
- **Moved divider**: The "or continue with" divider is now rendered inside `ExternalLoginPicker` (only when providers exist), removed from Login and Register pages. This makes the component self-contained.
- **No behavioral change** when OAuth providers are configured — everything renders as before.

Closes #193

## Test plan

- [ ] Start app with no Google/Microsoft OAuth credentials configured — Login and Register pages should show no placeholder text and no "or continue with" divider
- [ ] Configure OAuth credentials — Login and Register pages should show the divider and provider buttons as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)