### PR TITLE
feat: standardize loading states with shared LoadingSpinner component

### DIFF
--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor
@@ -24,7 +24,7 @@
 <div class="mp-detail-page">
     @if (_isLoading)
     {
-        <p class="mp-loading">Loading meal plan...</p>
+        <LoadingSpinner Message="Loading meal plan..." />
     }
     else if (_plan is null)
     {

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor.css
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor.css
@@ -33,14 +33,6 @@
     animation: sectionFadeIn 0.3s var(--ease-default) backwards;
 }
 
-/* ── Loading ─────────────────────────────────────────── */
-.mp-loading {
-    padding: var(--space-8);
-    text-align: center;
-    color: var(--color-text-muted);
-    font-size: var(--text-sm);
-}
-
 /* ── Not Found ───────────────────────────────────────── */
 .mp-not-found {
     padding: var(--space-16) var(--space-6);

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor
@@ -19,7 +19,7 @@
 <div class="mp-edit-page">
     @if (_isLoading)
     {
-        <p class="mp-loading">Loading meal plan...</p>
+        <LoadingSpinner Message="Loading meal plan..." />
     }
     else if (_plan is null)
     {

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor.css
@@ -31,14 +31,7 @@
     background: currentColor;
 }
 
-/* ── Loading / Not Found ─────────────────────────────── */
-.mp-loading {
-    padding: var(--space-8);
-    text-align: center;
-    color: var(--color-text-muted);
-    font-size: var(--text-sm);
-}
-
+/* ── Not Found ───────────────────────────────────────── */
 .table-card {
     background: var(--color-bg-card);
     border-radius: var(--radius-xl);

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor
@@ -21,10 +21,7 @@
 <div class="md-edit-page">
     @if (_isLoading)
     {
-        <div class="md-loading">
-            <div class="md-spinner"></div>
-            <span>Loading meal plan details...</span>
-        </div>
+        <LoadingSpinner Message="Loading meal plan details..." />
     }
     else if (_notFound)
     {

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor.css
@@ -22,30 +22,6 @@
     color: var(--color-text);
 }
 
-/* ── Loading State ────────────────────────────────────── */
-.md-loading {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    padding: var(--space-8);
-    justify-content: center;
-    color: var(--color-text-muted);
-    font-size: var(--text-sm);
-}
-
-.md-spinner {
-    width: 20px;
-    height: 20px;
-    border: 2px solid var(--color-border);
-    border-top-color: var(--color-primary);
-    border-radius: var(--radius-full);
-    animation: spin 0.6s linear infinite;
-}
-
-@keyframes spin {
-    to { transform: rotate(360deg); }
-}
-
 /* ── Not Found ────────────────────────────────────────── */
 .table-card {
     background: var(--color-bg-card);

--- a/src/Nutrir.Web/Components/Pages/Progress/ProgressEntryEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/Progress/ProgressEntryEdit.razor
@@ -23,7 +23,7 @@
 
     @if (_isLoading)
     {
-        <p class="form-loading">Loading...</p>
+        <LoadingSpinner />
     }
     else if (_entry is null)
     {

--- a/src/Nutrir.Web/Components/Shared/LoadingSpinner.razor
+++ b/src/Nutrir.Web/Components/Shared/LoadingSpinner.razor
@@ -1,0 +1,11 @@
+<div class="@CssClass">
+    <div class="loading-spinner"></div>
+    <span>@Message</span>
+</div>
+
+@code {
+    [Parameter] public string Message { get; set; } = "Loading...";
+    [Parameter] public bool Centered { get; set; } = true;
+
+    private string CssClass => Centered ? "loading-container loading-centered" : "loading-container";
+}

--- a/src/Nutrir.Web/Components/Shared/LoadingSpinner.razor.css
+++ b/src/Nutrir.Web/Components/Shared/LoadingSpinner.razor.css
@@ -1,0 +1,26 @@
+.loading-container {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-8);
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
+}
+
+.loading-centered {
+    justify-content: center;
+}
+
+.loading-spinner {
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    border: 3px solid var(--color-border);
+    border-top-color: var(--color-primary);
+    border-radius: 50%;
+    animation: loading-spin 0.8s linear infinite;
+}
+
+@keyframes loading-spin {
+    to { transform: rotate(360deg); }
+}

--- a/src/Nutrir.Web/Components/Widgets/ActiveMealPlanCard.razor
+++ b/src/Nutrir.Web/Components/Widgets/ActiveMealPlanCard.razor
@@ -13,7 +13,7 @@
     <ChildContent>
         @if (_loading)
         {
-            <div class="meal-plan-loading">Loading...</div>
+            <LoadingSpinner />
         }
         else if (_activePlan is not null)
         {

--- a/src/Nutrir.Web/Components/Widgets/ActiveMealPlanCard.razor.css
+++ b/src/Nutrir.Web/Components/Widgets/ActiveMealPlanCard.razor.css
@@ -1,11 +1,3 @@
-/* ── Loading ─────────────────────────────────────────── */
-.meal-plan-loading {
-    padding: var(--space-8);
-    text-align: center;
-    color: var(--color-text-muted);
-    font-size: var(--text-sm);
-}
-
 /* ── Plan Body ──────────────────────────────────────── */
 .meal-plan-body {
     padding: var(--space-4);

--- a/src/Nutrir.Web/Components/Widgets/ProgressSummaryWidget.razor
+++ b/src/Nutrir.Web/Components/Widgets/ProgressSummaryWidget.razor
@@ -15,7 +15,7 @@
             <div class="progress-body">
                 @if (_loading)
                 {
-                    <p>Loading...</p>
+                    <LoadingSpinner />
                 }
                 else if (!_hasData)
                 {

--- a/src/Nutrir.Web/Components/_Imports.razor
+++ b/src/Nutrir.Web/Components/_Imports.razor
@@ -9,6 +9,7 @@
 @using Microsoft.JSInterop
 @using Nutrir.Web
 @using Nutrir.Web.Components
+@using Nutrir.Web.Components.Shared
 @using Nutrir.Web.Components.UI
 @using Nutrir.Web.Components.UI.DataGrid
 @using Radzen.Blazor


### PR DESCRIPTION
## Summary

- Created a shared `LoadingSpinner.razor` component in `Components/Shared/` with configurable `Message` (default: "Loading...") and `Centered` parameters
- Spinner uses CSS `border-top-color` animation technique consistent with existing `AiAssistantPanel` spinner, sized at 24px for page-level use
- Replaced plain-text loading states in all 6 pages: `MealPlanEdit`, `MealPlanDetail`, `MealPlanMetadataEdit`, `ProgressEntryEdit`, `ActiveMealPlanCard`, `ProgressSummaryWidget`
- Removed orphaned CSS classes (`.mp-loading`, `.md-loading`, `.md-spinner`, `.meal-plan-loading`, `@keyframes spin`)

Closes #191

## Test plan

- [ ] Navigate to each meal plan page (create, edit, detail) and verify spinner appears during load
- [ ] Navigate to progress entry edit page and verify spinner appears during load
- [ ] Check dashboard widgets (ActiveMealPlanCard, ProgressSummaryWidget) show spinner while loading
- [ ] Verify all spinners look visually consistent (same size, color, animation speed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)