### PR TITLE
feat: add JS-side input debouncing for form text inputs

### DIFF
--- a/src/Nutrir.Web/Components/App.razor
+++ b/src/Nutrir.Web/Components/App.razor
@@ -41,6 +41,7 @@
     <script src="lib/qrcodejs/qrcode.min.js"></script>
     <script src="js/qr-authenticator.js"></script>
     <script src="js/calendar.js"></script>
+    <script src="js/debounce-input.js"></script>
 </body>
 
 </html>

--- a/src/Nutrir.Web/Components/Pages/Appointments/AppointmentCreate.razor
+++ b/src/Nutrir.Web/Components/Pages/Appointments/AppointmentCreate.razor
@@ -182,7 +182,8 @@
                         <FormInput Id="locationNotes"
                                    Value="@_model.LocationNotes"
                                    ValueChanged="@(v => _model.LocationNotes = v)"
-                                   Placeholder="Address or room number..." />
+                                   Placeholder="Address or room number..."
+                                   DebounceMs="300" />
                     </FormGroup>
                 }
 
@@ -192,7 +193,8 @@
                         <FormInput Id="virtualUrl" Type="url"
                                    Value="@_model.VirtualMeetingUrl"
                                    ValueChanged="@(v => _model.VirtualMeetingUrl = v)"
-                                   Placeholder="https://meet.example.com/..." />
+                                   Placeholder="https://meet.example.com/..."
+                                   DebounceMs="300" />
                     </FormGroup>
                 }
             </div>

--- a/src/Nutrir.Web/Components/Pages/Appointments/AppointmentEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/Appointments/AppointmentEdit.razor
@@ -164,7 +164,8 @@
                             <FormInput Id="virtualUrl" Type="url"
                                        Value="@_model.VirtualMeetingUrl"
                                        ValueChanged="@(v => _model.VirtualMeetingUrl = v)"
-                                       Placeholder="https://meet.example.com/..." />
+                                       Placeholder="https://meet.example.com/..."
+                                       DebounceMs="300" />
                         </FormGroup>
                     }
 
@@ -174,7 +175,8 @@
                             <FormInput Id="locationNotes"
                                        Value="@_model.LocationNotes"
                                        ValueChanged="@(v => _model.LocationNotes = v)"
-                                       Placeholder="Address or room number..." />
+                                       Placeholder="Address or room number..."
+                                       DebounceMs="300" />
                         </FormGroup>
                     }
 

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
@@ -52,14 +52,16 @@
                         <FormInput Id="firstName"
                                    Value="@_model.FirstName"
                                    ValueChanged="OnFirstNameChanged"
-                                   Placeholder="Enter first name" />
+                                   Placeholder="Enter first name"
+                                   DebounceMs="300" />
                     </FormGroup>
 
                     <FormGroup Label="Last Name" Id="lastName" Error="@GetFieldError(nameof(_model.LastName))">
                         <FormInput Id="lastName"
                                    Value="@_model.LastName"
                                    ValueChanged="OnLastNameChanged"
-                                   Placeholder="Enter last name" />
+                                   Placeholder="Enter last name"
+                                   DebounceMs="300" />
                     </FormGroup>
                 </div>
 
@@ -69,7 +71,8 @@
                                    Type="email"
                                    Value="@_model.Email"
                                    ValueChanged="@(v => _model.Email = v)"
-                                   Placeholder="email@example.com" />
+                                   Placeholder="email@example.com"
+                                   DebounceMs="300" />
                     </FormGroup>
 
                     <FormGroup Label="Phone" Id="phone">
@@ -77,7 +80,8 @@
                                    Type="tel"
                                    Value="@_model.Phone"
                                    ValueChanged="OnPhoneChanged"
-                                   Placeholder="(555) 123-4567" />
+                                   Placeholder="(555) 123-4567"
+                                   DebounceMs="300" />
                     </FormGroup>
                 </div>
 

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
@@ -72,14 +72,16 @@
                             <FormInput Id="firstName"
                                        Value="@_model.FirstName"
                                        ValueChanged="@(v => _model.FirstName = v)"
-                                       Placeholder="Enter first name" />
+                                       Placeholder="Enter first name"
+                                       DebounceMs="300" />
                         </FormGroup>
 
                         <FormGroup Label="Last Name" Id="lastName" Error="@GetFieldError(nameof(_model.LastName))">
                             <FormInput Id="lastName"
                                        Value="@_model.LastName"
                                        ValueChanged="@(v => _model.LastName = v)"
-                                       Placeholder="Enter last name" />
+                                       Placeholder="Enter last name"
+                                       DebounceMs="300" />
                         </FormGroup>
                     </div>
 
@@ -89,7 +91,8 @@
                                        Type="email"
                                        Value="@_model.Email"
                                        ValueChanged="@(v => _model.Email = v)"
-                                       Placeholder="email@example.com" />
+                                       Placeholder="email@example.com"
+                                       DebounceMs="300" />
                         </FormGroup>
 
                         <FormGroup Label="Phone" Id="phone">
@@ -97,7 +100,8 @@
                                        Type="tel"
                                        Value="@_model.Phone"
                                        ValueChanged="OnPhoneChanged"
-                                       Placeholder="(555) 123-4567" />
+                                       Placeholder="(555) 123-4567"
+                                       DebounceMs="300" />
                         </FormGroup>
                     </div>
 

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanCreate.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanCreate.razor
@@ -56,7 +56,8 @@
                         <FormInput Id="title"
                                    Value="@_model.Title"
                                    ValueChanged="@(v => _model.Title = v)"
-                                   Placeholder="e.g. Week 1 — Weight Loss" />
+                                   Placeholder="e.g. Week 1 — Weight Loss"
+                                   DebounceMs="300" />
                     </FormGroup>
 
                     <FormGroup Label="Description" Id="description">

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor
@@ -160,7 +160,8 @@
                                 <FormInput Id="@($"food-{slot.GetHashCode()}")"
                                            Placeholder="Food name"
                                            Value="@_newItem.FoodName"
-                                           ValueChanged="@(v => _newItem.FoodName = v)" />
+                                           ValueChanged="@(v => _newItem.FoodName = v)"
+                                           DebounceMs="300" />
                                 <FormInput Id="@($"qty-{slot.GetHashCode()}")"
                                            Type="number"
                                            Placeholder="Qty"

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanMetadataEdit.razor
@@ -76,7 +76,8 @@
                             <FormInput Id="title"
                                        Value="@_model.Title"
                                        ValueChanged="@(v => _model.Title = v)"
-                                       Placeholder="e.g. Week 1 — Weight Loss" />
+                                       Placeholder="e.g. Week 1 — Weight Loss"
+                                       DebounceMs="300" />
                         </FormGroup>
 
                         <FormGroup Label="Description" Id="description">

--- a/src/Nutrir.Web/Components/Pages/Progress/ProgressEntryCreate.razor
+++ b/src/Nutrir.Web/Components/Pages/Progress/ProgressEntryCreate.razor
@@ -61,7 +61,8 @@
                                     <FormInput Id="@($"custom-{idx}")"
                                                Value="@_model.Measurements[idx].CustomMetricName"
                                                ValueChanged="@(v => _model.Measurements[idx].CustomMetricName = v)"
-                                               Placeholder="e.g. Bicep circumference" />
+                                               Placeholder="e.g. Bicep circumference"
+                                               DebounceMs="300" />
                                 </FormGroup>
                             }
                             <div class="form-grid">
@@ -75,7 +76,8 @@
                                     <FormInput Id="@($"unit-{idx}")"
                                                Value="@_model.Measurements[idx].Unit"
                                                ValueChanged="@(v => _model.Measurements[idx].Unit = v)"
-                                               Placeholder="e.g. kg, %, cm" />
+                                               Placeholder="e.g. kg, %, cm"
+                                               DebounceMs="300" />
                                 </FormGroup>
                             </div>
                         </div>

--- a/src/Nutrir.Web/Components/Pages/Progress/ProgressEntryEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/Progress/ProgressEntryEdit.razor
@@ -72,7 +72,8 @@
                                     <FormGroup Label="Custom Name" Id="@($"custom-{idx}")">
                                         <FormInput Id="@($"custom-{idx}")"
                                                    Value="@_model.Measurements[idx].CustomMetricName"
-                                                   ValueChanged="@(v => _model.Measurements[idx].CustomMetricName = v)" />
+                                                   ValueChanged="@(v => _model.Measurements[idx].CustomMetricName = v)"
+                                                   DebounceMs="300" />
                                     </FormGroup>
                                 }
                                 <div class="form-grid">
@@ -84,7 +85,8 @@
                                     <FormGroup Label="Unit" Id="@($"unit-{idx}")">
                                         <FormInput Id="@($"unit-{idx}")"
                                                    Value="@_model.Measurements[idx].Unit"
-                                                   ValueChanged="@(v => _model.Measurements[idx].Unit = v)" />
+                                                   ValueChanged="@(v => _model.Measurements[idx].Unit = v)"
+                                                   DebounceMs="300" />
                                     </FormGroup>
                                 </div>
                             </div>

--- a/src/Nutrir.Web/Components/Pages/Progress/ProgressGoalModal.razor
+++ b/src/Nutrir.Web/Components/Pages/Progress/ProgressGoalModal.razor
@@ -24,7 +24,8 @@
                     <FormInput Id="goalTitle"
                                Value="@_model.Title"
                                ValueChanged="@(v => _model.Title = v)"
-                               Placeholder="e.g. Reach 75 kg" />
+                               Placeholder="e.g. Reach 75 kg"
+                               DebounceMs="300" />
                 </FormGroup>
 
                 <FormGroup Label="Goal Type" Id="goalType">
@@ -49,7 +50,8 @@
                         <FormInput Id="targetUnit"
                                    Value="@_model.TargetUnit"
                                    ValueChanged="@(v => _model.TargetUnit = v)"
-                                   Placeholder="e.g. kg, %" />
+                                   Placeholder="e.g. kg, %"
+                                   DebounceMs="300" />
                     </FormGroup>
                 </div>
 

--- a/src/Nutrir.Web/Components/Pages/Settings/AvailabilitySettings.razor
+++ b/src/Nutrir.Web/Components/Pages/Settings/AvailabilitySettings.razor
@@ -161,7 +161,8 @@
                             <FormInput Id="blockNotes"
                                        Value="@_newBlockNotes"
                                        ValueChanged="@(v => _newBlockNotes = v)"
-                                       Placeholder="Optional description..." />
+                                       Placeholder="Optional description..."
+                                       DebounceMs="300" />
                         </FormGroup>
                     </div>
                     <Button Variant="ButtonVariant.Outline" Disabled="@_isAddingBlock" OnClick="AddTimeBlock">

--- a/src/Nutrir.Web/Components/UI/FormInput.razor
+++ b/src/Nutrir.Web/Components/UI/FormInput.razor
@@ -1,10 +1,25 @@
-<input id="@Id"
-       type="@Type"
-       class="form-input"
-       value="@Value"
-       placeholder="@Placeholder"
-       @oninput="HandleInput"
-       @attributes="AdditionalAttributes" />
+@inject IJSRuntime JS
+@implements IAsyncDisposable
+
+@if (DebounceMs > 0)
+{
+    <input id="@_elementId"
+           type="@Type"
+           class="form-input"
+           value="@Value"
+           placeholder="@Placeholder"
+           @attributes="AdditionalAttributes" />
+}
+else
+{
+    <input id="@_elementId"
+           type="@Type"
+           class="form-input"
+           value="@Value"
+           placeholder="@Placeholder"
+           @oninput="HandleInput"
+           @attributes="AdditionalAttributes" />
+}
 
 @code {
     [Parameter] public string? Id { get; set; }
@@ -12,11 +27,51 @@
     [Parameter] public EventCallback<string> ValueChanged { get; set; }
     [Parameter] public string? Placeholder { get; set; }
     [Parameter] public string Type { get; set; } = "text";
+    [Parameter] public int DebounceMs { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string _elementId = default!;
+    private DotNetObjectReference<FormInput>? _dotNetRef;
+    private bool _jsInitialized;
+
+    protected override void OnInitialized()
+    {
+        _elementId = Id ?? $"fi-{Guid.NewGuid():N}";
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && DebounceMs > 0)
+        {
+            _dotNetRef = DotNetObjectReference.Create(this);
+            _jsInitialized = true;
+            await JS.InvokeVoidAsync("debounceInput.register", _elementId, _dotNetRef, DebounceMs);
+        }
+    }
 
     private async Task HandleInput(ChangeEventArgs e)
     {
         Value = e.Value?.ToString();
         await ValueChanged.InvokeAsync(Value);
+    }
+
+    [JSInvokable]
+    public async Task OnDebouncedInput(string value)
+    {
+        Value = value;
+        await ValueChanged.InvokeAsync(Value);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_jsInitialized)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("debounceInput.unregister", _elementId);
+            }
+            catch (JSDisconnectedException) { }
+        }
+        _dotNetRef?.Dispose();
     }
 }

--- a/src/Nutrir.Web/Components/Widgets/AllergiesSection.razor
+++ b/src/Nutrir.Web/Components/Widgets/AllergiesSection.razor
@@ -37,7 +37,8 @@
                                     <FormInput Id="edit-allergy-name"
                                                Value="@_editName"
                                                ValueChanged="@(v => _editName = v)"
-                                               Placeholder="Allergy name" />
+                                               Placeholder="Allergy name"
+                                               DebounceMs="300" />
                                 </FormGroup>
                                 <FormGroup Label="Severity" Id="edit-allergy-severity">
                                     <FormSelect Id="edit-allergy-severity"
@@ -115,7 +116,8 @@
                             <FormInput Id="add-allergy-name"
                                        Value="@_addName"
                                        ValueChanged="@(v => _addName = v)"
-                                       Placeholder="Allergy name" />
+                                       Placeholder="Allergy name"
+                                       DebounceMs="300" />
                         </FormGroup>
                         <FormGroup Label="Severity" Id="add-allergy-severity">
                             <FormSelect Id="add-allergy-severity"

--- a/src/Nutrir.Web/Components/Widgets/AllergyFormGroup.razor
+++ b/src/Nutrir.Web/Components/Widgets/AllergyFormGroup.razor
@@ -17,7 +17,8 @@
                     <FormInput Id="@($"allergy-name-{index}")"
                                Value="@entry.Name"
                                ValueChanged="@(v => entry.Name = v)"
-                               Placeholder="e.g. Peanuts" />
+                               Placeholder="e.g. Peanuts"
+                               DebounceMs="300" />
                 </FormGroup>
                 <FormGroup Label="Severity" Id="@($"allergy-severity-{index}")">
                     <FormSelect Id="@($"allergy-severity-{index}")"

--- a/src/Nutrir.Web/Components/Widgets/ConditionFormGroup.razor
+++ b/src/Nutrir.Web/Components/Widgets/ConditionFormGroup.razor
@@ -17,13 +17,15 @@
                     <FormInput Id="@($"cond-name-{index}")"
                                Value="@entry.Name"
                                ValueChanged="@(v => entry.Name = v)"
-                               Placeholder="e.g. Type 2 Diabetes" />
+                               Placeholder="e.g. Type 2 Diabetes"
+                               DebounceMs="300" />
                 </FormGroup>
                 <FormGroup Label="Code" Id="@($"cond-code-{index}")">
                     <FormInput Id="@($"cond-code-{index}")"
                                Value="@entry.Code"
                                ValueChanged="@(v => entry.Code = v)"
-                               Placeholder="e.g. E11" />
+                               Placeholder="e.g. E11"
+                               DebounceMs="300" />
                 </FormGroup>
                 <FormGroup Label="Diagnosis Date" Id="@($"cond-date-{index}")">
                     <FormInput Id="@($"cond-date-{index}")"

--- a/src/Nutrir.Web/Components/Widgets/ConditionsSection.razor
+++ b/src/Nutrir.Web/Components/Widgets/ConditionsSection.razor
@@ -37,13 +37,15 @@
                                     <FormInput Id="edit-cond-name"
                                                Value="@_editName"
                                                ValueChanged="@(v => _editName = v)"
-                                               Placeholder="Condition name" />
+                                               Placeholder="Condition name"
+                                               DebounceMs="300" />
                                 </FormGroup>
                                 <FormGroup Label="Code" Id="edit-cond-code">
                                     <FormInput Id="edit-cond-code"
                                                Value="@_editCode"
                                                ValueChanged="@(v => _editCode = v)"
-                                               Placeholder="e.g. ICD-10 code" />
+                                               Placeholder="e.g. ICD-10 code"
+                                               DebounceMs="300" />
                                 </FormGroup>
                                 <FormGroup Label="Diagnosis Date" Id="edit-cond-date">
                                     <FormInput Id="edit-cond-date"
@@ -140,13 +142,15 @@
                             <FormInput Id="add-cond-name"
                                        Value="@_addName"
                                        ValueChanged="@(v => _addName = v)"
-                                       Placeholder="Condition name" />
+                                       Placeholder="Condition name"
+                                       DebounceMs="300" />
                         </FormGroup>
                         <FormGroup Label="Code" Id="add-cond-code">
                             <FormInput Id="add-cond-code"
                                        Value="@_addCode"
                                        ValueChanged="@(v => _addCode = v)"
-                                       Placeholder="e.g. ICD-10 code" />
+                                       Placeholder="e.g. ICD-10 code"
+                                       DebounceMs="300" />
                         </FormGroup>
                         <FormGroup Label="Diagnosis Date" Id="add-cond-date">
                             <FormInput Id="add-cond-date"

--- a/src/Nutrir.Web/Components/Widgets/DietaryRestrictionFormGroup.razor
+++ b/src/Nutrir.Web/Components/Widgets/DietaryRestrictionFormGroup.razor
@@ -28,7 +28,8 @@
                     <FormInput Id="@($"dr-notes-{index}")"
                                Value="@entry.Notes"
                                ValueChanged="@(v => entry.Notes = v)"
-                               Placeholder="Additional details" />
+                               Placeholder="Additional details"
+                               DebounceMs="300" />
                 </FormGroup>
             </div>
             <button class="health-form-remove" type="button" @onclick="@(() => Remove(index))" title="Remove">

--- a/src/Nutrir.Web/Components/Widgets/DietaryRestrictionsSection.razor
+++ b/src/Nutrir.Web/Components/Widgets/DietaryRestrictionsSection.razor
@@ -47,7 +47,8 @@
                                     <FormInput Id="edit-dr-notes"
                                                Value="@_editNotes"
                                                ValueChanged="@(v => _editNotes = v)"
-                                               Placeholder="Additional details" />
+                                               Placeholder="Additional details"
+                                               DebounceMs="300" />
                                 </FormGroup>
                             </div>
                             @if (!string.IsNullOrEmpty(_formError))
@@ -115,7 +116,8 @@
                             <FormInput Id="add-dr-notes"
                                        Value="@_addNotes"
                                        ValueChanged="@(v => _addNotes = v)"
-                                       Placeholder="Additional details" />
+                                       Placeholder="Additional details"
+                                       DebounceMs="300" />
                         </FormGroup>
                     </div>
                     @if (!string.IsNullOrEmpty(_formError))

--- a/src/Nutrir.Web/Components/Widgets/MedicationFormGroup.razor
+++ b/src/Nutrir.Web/Components/Widgets/MedicationFormGroup.razor
@@ -16,25 +16,29 @@
                     <FormInput Id="@($"med-name-{index}")"
                                Value="@entry.Name"
                                ValueChanged="@(v => entry.Name = v)"
-                               Placeholder="e.g. Metformin" />
+                               Placeholder="e.g. Metformin"
+                               DebounceMs="300" />
                 </FormGroup>
                 <FormGroup Label="Dosage" Id="@($"med-dosage-{index}")">
                     <FormInput Id="@($"med-dosage-{index}")"
                                Value="@entry.Dosage"
                                ValueChanged="@(v => entry.Dosage = v)"
-                               Placeholder="e.g. 500mg" />
+                               Placeholder="e.g. 500mg"
+                               DebounceMs="300" />
                 </FormGroup>
                 <FormGroup Label="Frequency" Id="@($"med-freq-{index}")">
                     <FormInput Id="@($"med-freq-{index}")"
                                Value="@entry.Frequency"
                                ValueChanged="@(v => entry.Frequency = v)"
-                               Placeholder="e.g. Twice daily" />
+                               Placeholder="e.g. Twice daily"
+                               DebounceMs="300" />
                 </FormGroup>
                 <FormGroup Label="Prescribed For" Id="@($"med-for-{index}")">
                     <FormInput Id="@($"med-for-{index}")"
                                Value="@entry.PrescribedFor"
                                ValueChanged="@(v => entry.PrescribedFor = v)"
-                               Placeholder="e.g. Type 2 Diabetes" />
+                               Placeholder="e.g. Type 2 Diabetes"
+                               DebounceMs="300" />
                 </FormGroup>
             </div>
             <button class="health-form-remove" type="button" @onclick="@(() => Remove(index))" title="Remove">

--- a/src/Nutrir.Web/Components/Widgets/MedicationsSection.razor
+++ b/src/Nutrir.Web/Components/Widgets/MedicationsSection.razor
@@ -36,25 +36,29 @@
                                     <FormInput Id="edit-med-name"
                                                Value="@_editName"
                                                ValueChanged="@(v => _editName = v)"
-                                               Placeholder="Medication name" />
+                                               Placeholder="Medication name"
+                                               DebounceMs="300" />
                                 </FormGroup>
                                 <FormGroup Label="Dosage" Id="edit-med-dosage">
                                     <FormInput Id="edit-med-dosage"
                                                Value="@_editDosage"
                                                ValueChanged="@(v => _editDosage = v)"
-                                               Placeholder="e.g. 500mg" />
+                                               Placeholder="e.g. 500mg"
+                                               DebounceMs="300" />
                                 </FormGroup>
                                 <FormGroup Label="Frequency" Id="edit-med-freq">
                                     <FormInput Id="edit-med-freq"
                                                Value="@_editFrequency"
                                                ValueChanged="@(v => _editFrequency = v)"
-                                               Placeholder="e.g. Twice daily" />
+                                               Placeholder="e.g. Twice daily"
+                                               DebounceMs="300" />
                                 </FormGroup>
                                 <FormGroup Label="Prescribed For" Id="edit-med-for">
                                     <FormInput Id="edit-med-for"
                                                Value="@_editPrescribedFor"
                                                ValueChanged="@(v => _editPrescribedFor = v)"
-                                               Placeholder="e.g. Hypertension" />
+                                               Placeholder="e.g. Hypertension"
+                                               DebounceMs="300" />
                                 </FormGroup>
                             </div>
                             @if (!string.IsNullOrEmpty(_formError))
@@ -126,25 +130,29 @@
                             <FormInput Id="add-med-name"
                                        Value="@_addName"
                                        ValueChanged="@(v => _addName = v)"
-                                       Placeholder="Medication name" />
+                                       Placeholder="Medication name"
+                                       DebounceMs="300" />
                         </FormGroup>
                         <FormGroup Label="Dosage" Id="add-med-dosage">
                             <FormInput Id="add-med-dosage"
                                        Value="@_addDosage"
                                        ValueChanged="@(v => _addDosage = v)"
-                                       Placeholder="e.g. 500mg" />
+                                       Placeholder="e.g. 500mg"
+                                       DebounceMs="300" />
                         </FormGroup>
                         <FormGroup Label="Frequency" Id="add-med-freq">
                             <FormInput Id="add-med-freq"
                                        Value="@_addFrequency"
                                        ValueChanged="@(v => _addFrequency = v)"
-                                       Placeholder="e.g. Twice daily" />
+                                       Placeholder="e.g. Twice daily"
+                                       DebounceMs="300" />
                         </FormGroup>
                         <FormGroup Label="Prescribed For" Id="add-med-for">
                             <FormInput Id="add-med-for"
                                        Value="@_addPrescribedFor"
                                        ValueChanged="@(v => _addPrescribedFor = v)"
-                                       Placeholder="e.g. Hypertension" />
+                                       Placeholder="e.g. Hypertension"
+                                       DebounceMs="300" />
                         </FormGroup>
                     </div>
                     @if (!string.IsNullOrEmpty(_formError))

--- a/src/Nutrir.Web/wwwroot/js/debounce-input.js
+++ b/src/Nutrir.Web/wwwroot/js/debounce-input.js
@@ -1,0 +1,34 @@
+window.debounceInput = {
+    _handlers: {},
+
+    register: function (elementId, dotNetRef, debounceMs) {
+        var element = document.getElementById(elementId);
+        if (!element) return;
+
+        // Clean up any existing handler
+        this.unregister(elementId);
+
+        var self = this;
+        var handler = function (e) {
+            var entry = self._handlers[elementId];
+            if (entry) {
+                if (entry.timer) clearTimeout(entry.timer);
+                entry.timer = setTimeout(function () {
+                    dotNetRef.invokeMethodAsync('OnDebouncedInput', e.target.value);
+                }, debounceMs);
+            }
+        };
+
+        element.addEventListener('input', handler);
+        this._handlers[elementId] = { handler: handler, element: element, timer: null };
+    },
+
+    unregister: function (elementId) {
+        var entry = this._handlers[elementId];
+        if (entry) {
+            if (entry.timer) clearTimeout(entry.timer);
+            entry.element.removeEventListener('input', entry.handler);
+            delete this._handlers[elementId];
+        }
+    }
+};


### PR DESCRIPTION
## Summary

- Added a `DebounceMs` parameter to `FormInput.razor` that buffers keystrokes **client-side via JS interop**, eliminating SignalR round-trips during typing
- Created `wwwroot/js/debounce-input.js` — lightweight JS utility that intercepts `input` events and only invokes .NET after the debounce delay
- Applied `DebounceMs="300"` to all text/email/url inputs across 20 form pages and widget sections
- When `DebounceMs` is 0 (default), the component works exactly as before — no behavioral change for non-debounced inputs

### Key design decisions
- **JS-side debouncing** (not server-side Timer) — prevents SignalR round-trips entirely during typing, critical for high-latency connections (300ms+ RTT)
- **Conditional rendering** — when debouncing is active, the `<input>` element omits `@oninput` entirely so Blazor doesn't intercept DOM events
- **Proper cleanup** — `IAsyncDisposable` with `JSDisconnectedException` handling for Blazor Server circuit teardown
- **Not debounced**: `date`, `time`, `number` inputs — these use browser-native controls where immediate updates are expected

Closes #194

## Test plan
- [ ] Verify text inputs on ClientCreate/ClientEdit feel responsive when typing (no per-keystroke lag)
- [ ] Verify form submission still works correctly with debounced inputs
- [ ] Verify phone formatting still applies correctly on ClientCreate/ClientEdit
- [ ] Verify date/time/number inputs still update immediately (not debounced)
- [ ] Verify no console errors related to JS interop on page navigation
- [ ] Test on a high-latency connection (300ms+ RTT) to confirm improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)