### PR TITLE
feat: wire up EnsureMedicationsInLookupAsync on ClientCreate and ClientEdit

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientCreate.razor
@@ -346,6 +346,9 @@
             // Save health profile entries
             await SaveHealthProfileAsync(created.Id, userId);
 
+            // Ensure medications are in the lookup table for future auto-complete
+            await _medicationFormGroup.EnsureMedicationsInLookupAsync(userId);
+
             // Record consent form based on method
             if (isDigital)
             {

--- a/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/Clients/ClientEdit.razor
@@ -444,6 +444,10 @@
             {
                 // Save health profile changes (delete all existing, re-create from form)
                 await SaveHealthProfileChangesAsync(userId);
+
+                // Ensure medications are in the lookup table for future auto-complete
+                await _medicationFormGroup.EnsureMedicationsInLookupAsync(userId);
+
                 NavigationManager.NavigateTo($"/clients/{Id}");
             }
             else


### PR DESCRIPTION
## Summary

- Calls `MedicationFormGroup.EnsureMedicationsInLookupAsync(userId)` after saving health profile entries in `ClientCreate.razor`
- Calls the same method after saving health profile changes in `ClientEdit.razor`
- Ensures medications entered during client creation/editing are added to the lookup table for future auto-complete suggestions

Closes #212

## Test plan

- [ ] Create a new client with medications → verify those medications appear as auto-complete suggestions when creating/editing another client
- [ ] Edit an existing client's medications → verify new medications appear as auto-complete suggestions afterward
- [ ] Verify existing save/navigate flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)