### PR TITLE
feat: add email support via Gmail SMTP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
       - Elasticsearch__Url=${ELASTICSEARCH_URL:-}
       - Elasticsearch__ApiKey=${ELASTICSEARCH_API_KEY:-}
       - Anthropic__ApiKey=${ANTHROPIC_API_KEY:-}
+      - Smtp__SenderEmail=${SMTP_SENDER_EMAIL:-}
+      - Smtp__Username=${SMTP_USERNAME:-}
+      - Smtp__Password=${SMTP_PASSWORD:-}
 
   db:
     image: postgres:17

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,8 @@ Organized by domain. Each folder contains specs, designs, and decisions for that
 | [AI Assistant](infrastructure/ai-assistant-spec.md) | AI assistant panel — architecture, 38 tools, confirmation flow, streaming, markdown rendering, persistence, rate limiting, usage tracking |
 | [Seed Data Generator](infrastructure/seed-data-generator.md) | Dynamic development seed data — Bogus-powered profile-driven generator, configuration, food database, extending |
 | [Real-Time Notifications](infrastructure/real-time-notifications.md) | In-process event bus architecture, notification payload, dispatch points, consumer pages, integration pattern |
+| [Email Service](infrastructure/email-service.md) | MailKit/Gmail SMTP implementation — architecture, SmtpOptions, DI registration, usage examples, future considerations |
+| [Gmail SMTP Setup](infrastructure/gmail-smtp-setup.md) | Practitioner setup guide — App Password, SPF/DKIM/DMARC DNS records, .env configuration, sending limits, DMARC progression |
 
 ## Design System Documents
 

--- a/docs/infrastructure/email-service.md
+++ b/docs/infrastructure/email-service.md
@@ -1,0 +1,168 @@
+# Email Service
+
+Nutrir sends transactional email (intake form links, appointment confirmations, etc.) via MailKit over Gmail SMTP. The implementation follows the standard Core/Infrastructure split: an interface in `Nutrir.Core` defines the contract, and a MailKit-backed class in `Nutrir.Infrastructure` provides the implementation.
+
+## Architecture
+
+```
+Nutrir.Core
+└── Interfaces/IEmailService.cs       ← contract consumed by application code
+
+Nutrir.Infrastructure
+├── Configuration/SmtpOptions.cs      ← typed options class
+└── Services/EmailService.cs          ← MailKit implementation
+```
+
+Callers depend only on `IEmailService` and never reference MailKit or `SmtpOptions` directly.
+
+### Key Files
+
+| File | Project | Purpose |
+|------|---------|---------|
+| `src/Nutrir.Core/Interfaces/IEmailService.cs` | Core | Service interface |
+| `src/Nutrir.Infrastructure/Configuration/SmtpOptions.cs` | Infrastructure | Typed options bound to the `Smtp` config section |
+| `src/Nutrir.Infrastructure/Services/EmailService.cs` | Infrastructure | MailKit-based implementation |
+| `src/Nutrir.Infrastructure/DependencyInjection.cs` | Infrastructure | DI registration |
+
+## Interface
+
+```csharp
+public interface IEmailService
+{
+    Task SendEmailAsync(string to, string subject, string htmlBody,
+        CancellationToken ct = default);
+
+    Task SendEmailAsync(string to, string? toName, string subject, string htmlBody,
+        CancellationToken ct = default);
+}
+```
+
+The two overloads differ only in whether a display name is included for the recipient. Both accept HTML content for `htmlBody`.
+
+## Configuration
+
+### SmtpOptions
+
+`SmtpOptions` is a typed options class bound to the `Smtp` section of `appsettings.json`:
+
+```csharp
+public class SmtpOptions
+{
+    public const string SectionName = "Smtp";
+
+    public string Host { get; set; } = "smtp.gmail.com";
+    public int Port { get; set; } = 587;
+    public string SenderEmail { get; set; } = string.Empty;
+    public string SenderName { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}
+```
+
+### appsettings.json Defaults
+
+Non-sensitive defaults are committed to `appsettings.json`:
+
+```json
+{
+  "Smtp": {
+    "Host": "smtp.gmail.com",
+    "Port": 587,
+    "SenderName": "Nutrir"
+  }
+}
+```
+
+`SenderEmail`, `Username`, and `Password` are intentionally absent from `appsettings.json` and must be provided via environment variables.
+
+### Docker Environment Variables
+
+`docker-compose.yml` passes the three sensitive values into the `app` service:
+
+```yaml
+- Smtp__SenderEmail=${SMTP_SENDER_EMAIL:-}
+- Smtp__Username=${SMTP_USERNAME:-}
+- Smtp__Password=${SMTP_PASSWORD:-}
+```
+
+Set these in your `.env` file. See [Gmail SMTP Setup](gmail-smtp-setup.md) for instructions on obtaining these values and configuring DNS for deliverability.
+
+### Full Configuration Reference
+
+| Property | appsettings.json default | Environment variable | Description |
+|----------|--------------------------|----------------------|-------------|
+| `Host` | `smtp.gmail.com` | `Smtp__Host` | SMTP server hostname |
+| `Port` | `587` | `Smtp__Port` | SMTP port (STARTTLS) |
+| `SenderName` | `Nutrir` | `Smtp__SenderName` | Display name shown in "From" |
+| `SenderEmail` | _(empty)_ | `Smtp__SenderEmail` | "From" email address |
+| `Username` | _(empty)_ | `Smtp__Username` | SMTP authentication username |
+| `Password` | _(empty)_ | `Smtp__Password` | SMTP authentication password / App Password |
+
+## Implementation Details
+
+`EmailService` creates a new `SmtpClient` (MailKit) per send operation. Each call to `SendInternalAsync`:
+
+1. Builds a `MimeMessage` with the configured sender, the recipient address (and optional display name), subject, and an HTML body part.
+2. Connects to the configured host and port using `SecureSocketOptions.StartTls` (STARTTLS on port 587).
+3. Authenticates with the configured username and password.
+4. Sends the message.
+5. Disconnects in a `finally` block, regardless of send success or failure.
+
+A structured log event at `Information` level is emitted on successful delivery, including the recipient address and subject.
+
+Errors during connection, authentication, or sending propagate as exceptions to the caller. No retry logic is built in at the service layer.
+
+## Dependency Injection
+
+Registration is in `Nutrir.Infrastructure/DependencyInjection.cs`:
+
+```csharp
+services.Configure<SmtpOptions>(configuration.GetSection(SmtpOptions.SectionName));
+services.AddSingleton<IEmailService, EmailService>();
+```
+
+`EmailService` is registered as a **singleton**. The service is stateless — it creates and disposes a new `SmtpClient` per call rather than holding a long-lived connection, so there are no thread-safety or resource sharing concerns.
+
+## Usage
+
+Inject `IEmailService` into any service or Blazor component that needs to send email:
+
+```csharp
+public class IntakeFormService
+{
+    private readonly IEmailService _emailService;
+
+    public IntakeFormService(IEmailService emailService)
+    {
+        _emailService = emailService;
+    }
+
+    public async Task SendIntakeLinkAsync(string clientEmail, string clientName, string link, CancellationToken ct)
+    {
+        var subject = "Please complete your intake form";
+        var body = $"<p>Hi {clientName},</p><p>Please complete your intake form: <a href=\"{link}\">{link}</a></p>";
+
+        await _emailService.SendEmailAsync(clientEmail, clientName, subject, body, ct);
+    }
+}
+```
+
+For callers that do not have a display name available, use the two-parameter overload:
+
+```csharp
+await _emailService.SendEmailAsync(recipientAddress, subject, htmlBody, ct);
+```
+
+## NuGet Packages
+
+| Package | Purpose |
+|---------|---------|
+| `MailKit` | SMTP client, MIME construction |
+| `MimeKit` | MIME message model (`MimeMessage`, `MailboxAddress`, `TextPart`) |
+
+## Future Considerations
+
+- **HTML email templates**: The service accepts raw HTML strings. A templating layer (e.g., Razor-rendered templates via `RazorLightEngine`, or a Fluid/Scriban template engine) could produce consistent branded messages without embedding HTML in service code.
+- **Queue and retry**: For reliability, email sending should be moved off the request path. An outbox pattern (persist to a `PendingEmails` table, process via a background `IHostedService`) would survive transient SMTP failures and application restarts.
+- **ASP.NET Core Identity integration**: Identity's `IEmailSender<TUser>` interface can be implemented on top of `IEmailService` to enable password reset and email confirmation flows without referencing MailKit from the Identity layer.
+- **Alternative providers**: If volume outgrows Gmail's 2,000/day limit, `EmailService` can be replaced with a SendGrid or Postmark implementation — callers depend only on `IEmailService` and require no changes.

--- a/docs/infrastructure/gmail-smtp-setup.md
+++ b/docs/infrastructure/gmail-smtp-setup.md
@@ -1,0 +1,114 @@
+# Gmail SMTP Setup Guide
+
+Configuration guide for practitioners and administrators deploying Nutrir with Gmail as the outbound email provider.
+
+## Prerequisites
+
+- A **Google Workspace** account (e.g., Workspace Starter, Business Starter, or higher). Consumer Gmail accounts (`@gmail.com`) work for testing but have tighter rate limits and are not recommended for production.
+- Administrative access to the Google account that will send email on behalf of the practice.
+- DNS management access to your domain (for deliverability records).
+
+## Step 1: Enable 2-Step Verification
+
+Google App Passwords (required in Step 2) are only available on accounts with 2-Step Verification active.
+
+1. Sign in to the Google account at [myaccount.google.com](https://myaccount.google.com).
+2. Navigate to **Security**.
+3. Under "How you sign in to Google," select **2-Step Verification**.
+4. Follow the prompts to enable it.
+
+## Step 2: Generate an App Password
+
+App Passwords let a specific application authenticate with your Google account without using your main password, and without requiring OAuth.
+
+1. Return to **Security** in [myaccount.google.com](https://myaccount.google.com).
+2. Under "How you sign in to Google," select **App passwords** (only visible once 2-Step Verification is enabled).
+3. In the "App name" field, enter a descriptive label such as `Nutrir`.
+4. Click **Create**.
+5. Google displays a 16-character password. **Copy it immediately** — it is not shown again.
+
+This value becomes `SMTP_PASSWORD` in your `.env` file.
+
+## Step 3: Configure DNS Records for Deliverability
+
+Without proper DNS records, outbound email is likely to land in recipients' spam folders or be rejected outright. Configure the following records on your domain.
+
+### SPF
+
+Authorizes Gmail's servers to send email on behalf of your domain.
+
+| Type | Host | Value |
+|------|------|-------|
+| TXT | `@` (or your domain) | `v=spf1 include:_spf.google.com ~all` |
+
+If you already have an SPF record, add `include:_spf.google.com` to the existing record rather than creating a second TXT record. Only one SPF record per domain is valid.
+
+### DKIM
+
+Adds a cryptographic signature to outgoing messages so receiving servers can verify authenticity.
+
+1. In the Google Admin console ([admin.google.com](https://admin.google.com)), navigate to **Apps > Google Workspace > Gmail > Authenticate email**.
+2. Select your domain and click **Generate new record**.
+3. Google provides a TXT record with a selector (e.g., `google._domainkey`) and a long public key value.
+4. Add that record to your DNS exactly as shown.
+5. Return to the Admin console and click **Start authentication** once DNS has propagated.
+
+### DMARC
+
+Tells receiving mail servers what to do with messages that fail SPF or DKIM checks, and where to send aggregate reports.
+
+Add the following TXT record, substituting your actual email address for the `rua` report destination:
+
+| Type | Host | Value |
+|------|------|-------|
+| TXT | `_dmarc` | `v=DMARC1; p=none; rua=mailto:dmarc-reports@yourdomain.com` |
+
+See the [DMARC progression strategy](#dmarc-progression-strategy) section below before tightening the policy.
+
+## Step 4: Configure the .env File
+
+Nutrir reads SMTP credentials from environment variables. In your `.env` file (copy from `.env.example` if starting fresh):
+
+```
+SMTP_SENDER_EMAIL=hello@yourdomain.com
+SMTP_USERNAME=hello@yourdomain.com
+SMTP_PASSWORD=abcd efgh ijkl mnop
+```
+
+| Variable | Description |
+|----------|-------------|
+| `SMTP_SENDER_EMAIL` | The "From" address shown to recipients. Must be the Gmail/Workspace address. |
+| `SMTP_USERNAME` | The Gmail/Workspace address used to authenticate with Google's SMTP server. Usually identical to `SMTP_SENDER_EMAIL`. |
+| `SMTP_PASSWORD` | The 16-character App Password generated in Step 2 (not your regular Google account password). |
+
+The host (`smtp.gmail.com`), port (`587`), and sender name (`Nutrir`) are pre-configured in `appsettings.json` and do not need to be set in `.env` unless you want to override them.
+
+After editing `.env`, restart the application:
+
+```bash
+docker compose up -d --force-recreate app
+```
+
+## Sending Limits
+
+| Account Type | Daily Limit |
+|--------------|-------------|
+| Google Workspace Starter | 2,000 messages/day |
+| Google Workspace Business/Enterprise | 2,000 messages/day (per user) |
+| Consumer Gmail (`@gmail.com`) | 500 messages/day |
+
+Nutrir's current email usage (intake form notifications, appointment confirmations) is well within these limits for typical private practices. If volume grows significantly, consider a dedicated transactional email provider such as SendGrid or Postmark.
+
+## DMARC Progression Strategy
+
+Start with `p=none` (monitor mode) and tighten the policy only after confirming all legitimate email passes SPF and DKIM. A typical progression:
+
+| Phase | Policy | When to Move On |
+|-------|--------|-----------------|
+| 1 — Monitor | `p=none` | After 2–4 weeks with no legitimate failures in aggregate reports |
+| 2 — Quarantine | `p=quarantine` | After another 2–4 weeks of clean reports |
+| 3 — Reject | `p=reject` | When confident all outbound email is covered by SPF and DKIM |
+
+Update the `_dmarc` TXT record by changing the `p=` value at each stage. No application changes are required.
+
+Aggregate reports (`rua`) are sent by receiving mail servers to the address you specified. Tools such as [dmarcian](https://dmarcian.com) or [MXToolbox](https://mxtoolbox.com/dmarc.aspx) can parse and visualize these reports.

--- a/src/Nutrir.Core/Interfaces/IEmailService.cs
+++ b/src/Nutrir.Core/Interfaces/IEmailService.cs
@@ -1,0 +1,7 @@
+namespace Nutrir.Core.Interfaces;
+
+public interface IEmailService
+{
+    Task SendEmailAsync(string to, string subject, string htmlBody, CancellationToken ct = default);
+    Task SendEmailAsync(string to, string? toName, string subject, string htmlBody, CancellationToken ct = default);
+}

--- a/src/Nutrir.Infrastructure/Configuration/SmtpOptions.cs
+++ b/src/Nutrir.Infrastructure/Configuration/SmtpOptions.cs
@@ -1,0 +1,13 @@
+namespace Nutrir.Infrastructure.Configuration;
+
+public class SmtpOptions
+{
+    public const string SectionName = "Smtp";
+
+    public string Host { get; set; } = "smtp.gmail.com";
+    public int Port { get; set; } = 587;
+    public string SenderEmail { get; set; } = string.Empty;
+    public string SenderName { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/Nutrir.Infrastructure/DependencyInjection.cs
+++ b/src/Nutrir.Infrastructure/DependencyInjection.cs
@@ -60,6 +60,10 @@ public static class DependencyInjection
         services.AddSingleton<IAiMarkdownRenderer, AiMarkdownRenderer>();
         services.AddSingleton<IAiSuggestionService, AiSuggestionService>();
 
+        // Email
+        services.Configure<SmtpOptions>(configuration.GetSection(SmtpOptions.SectionName));
+        services.AddSingleton<IEmailService, EmailService>();
+
         return services;
     }
 }

--- a/src/Nutrir.Infrastructure/Nutrir.Infrastructure.csproj
+++ b/src/Nutrir.Infrastructure/Nutrir.Infrastructure.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MailKit" Version="4.15.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.2" />

--- a/src/Nutrir.Infrastructure/Services/EmailService.cs
+++ b/src/Nutrir.Infrastructure/Services/EmailService.cs
@@ -1,0 +1,64 @@
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MimeKit;
+using Nutrir.Core.Interfaces;
+using Nutrir.Infrastructure.Configuration;
+
+namespace Nutrir.Infrastructure.Services;
+
+public class EmailService : IEmailService
+{
+    private readonly SmtpOptions _options;
+    private readonly ILogger<EmailService> _logger;
+
+    public EmailService(IOptions<SmtpOptions> options, ILogger<EmailService> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public Task SendEmailAsync(string to, string subject, string htmlBody, CancellationToken ct = default)
+        => SendEmailAsync(to, toName: null, subject, htmlBody, ct);
+
+    public Task SendEmailAsync(string to, string? toName, string subject, string htmlBody, CancellationToken ct = default)
+        => SendInternalAsync(to, toName, subject, htmlBody, ct);
+
+    private async Task SendInternalAsync(string to, string? toName, string subject, string htmlBody, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(to, nameof(to));
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject, nameof(subject));
+        ArgumentNullException.ThrowIfNull(htmlBody, nameof(htmlBody));
+
+        var message = new MimeMessage();
+        message.From.Add(new MailboxAddress(_options.SenderName, _options.SenderEmail));
+        message.To.Add(new MailboxAddress(toName, to));
+        message.Subject = subject;
+
+        message.Body = new TextPart("html")
+        {
+            Text = htmlBody
+        };
+
+        using var client = new SmtpClient();
+
+        try
+        {
+            await client.ConnectAsync(_options.Host, _options.Port, SecureSocketOptions.StartTls, ct);
+            await client.AuthenticateAsync(_options.Username, _options.Password, ct);
+            await client.SendAsync(message, ct);
+
+            _logger.LogInformation("Email sent to {Recipient} with subject \"{Subject}\"", to, subject);
+        }
+        catch (Exception ex) when (ex is SmtpCommandException or SmtpProtocolException or AuthenticationException)
+        {
+            _logger.LogError(ex, "Failed to send email to {Recipient} with subject \"{Subject}\"", to, subject);
+            throw;
+        }
+        finally
+        {
+            await client.DisconnectAsync(quit: true, CancellationToken.None);
+        }
+    }
+}

--- a/src/Nutrir.Web/appsettings.json
+++ b/src/Nutrir.Web/appsettings.json
@@ -55,5 +55,8 @@
     "PracticeName": "Nutrir Nutrition Practice",
     "ScannedCopyStoragePath": "uploads/consent-scans"
   },
+  "Smtp": {
+    "SenderName": "Nutrir"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- Add `IEmailService` / `EmailService` using MailKit for sending HTML emails via Gmail SMTP (STARTTLS, port 587)
- `SmtpOptions` configuration bound from `appsettings.json` + environment variables for secrets
- Docker Compose wired with `SMTP_SENDER_EMAIL`, `SMTP_USERNAME`, `SMTP_PASSWORD` env vars
- Documentation: practitioner Gmail setup guide and developer technical reference

## Details
- **Interface:** `IEmailService` with two `SendEmailAsync` overloads (with/without recipient display name)
- **Implementation:** Stateless singleton, creates a new `SmtpClient` per send, input validation, structured logging, SMTP error logging
- **Config:** Non-secret defaults in `appsettings.json`, secrets via `.env` → docker-compose env vars
- **Docs:** `docs/infrastructure/gmail-smtp-setup.md` (SPF/DKIM/DMARC, App Password) + `docs/infrastructure/email-service.md` (architecture, usage examples)

## Test plan
- [ ] Add SMTP credentials to `.env` file
- [ ] `docker compose up --build` — verify app starts without errors
- [ ] Inject `IEmailService` into a test endpoint and send a test email
- [ ] Verify email arrives and passes SPF/DKIM checks in Gmail headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)