### PR TITLE
feat: enforce practitioner availability on appointment booking

### DIFF
--- a/src/Nutrir.Core/Interfaces/IAvailabilityService.cs
+++ b/src/Nutrir.Core/Interfaces/IAvailabilityService.cs
@@ -19,4 +19,7 @@ public interface IAvailabilityService
     Task<int> GetBufferTimeMinutesAsync(string practitionerId);
 
     Task SetBufferTimeMinutesAsync(string practitionerId, int minutes, string userId);
+
+    Task<(bool IsWithin, string? Reason)> IsSlotWithinScheduleAsync(
+        string practitionerId, DateTime startTimeUtc, int durationMinutes);
 }

--- a/src/Nutrir.Infrastructure/Services/AppointmentService.cs
+++ b/src/Nutrir.Infrastructure/Services/AppointmentService.cs
@@ -14,6 +14,7 @@ public class AppointmentService : IAppointmentService
     private readonly AppDbContext _dbContext;
     private readonly IDbContextFactory<AppDbContext> _dbContextFactory;
     private readonly IAuditLogService _auditLogService;
+    private readonly IAvailabilityService _availabilityService;
     private readonly INotificationDispatcher _notificationDispatcher;
     private readonly ILogger<AppointmentService> _logger;
 
@@ -21,12 +22,14 @@ public class AppointmentService : IAppointmentService
         AppDbContext dbContext,
         IDbContextFactory<AppDbContext> dbContextFactory,
         IAuditLogService auditLogService,
+        IAvailabilityService availabilityService,
         INotificationDispatcher notificationDispatcher,
         ILogger<AppointmentService> logger)
     {
         _dbContext = dbContext;
         _dbContextFactory = dbContextFactory;
         _auditLogService = auditLogService;
+        _availabilityService = availabilityService;
         _notificationDispatcher = notificationDispatcher;
         _logger = logger;
     }
@@ -175,6 +178,11 @@ public class AppointmentService : IAppointmentService
 
     public async Task<AppointmentDto> CreateAsync(CreateAppointmentDto dto, string userId)
     {
+        var (isWithin, reason) = await _availabilityService
+            .IsSlotWithinScheduleAsync(userId, dto.StartTime, dto.DurationMinutes);
+        if (!isWithin)
+            throw new SchedulingConflictException("Outside working hours", reason!);
+
         await CheckOverlapAsync(_dbContext, userId, dto.StartTime, dto.DurationMinutes);
 
         var entity = new Appointment
@@ -219,9 +227,14 @@ public class AppointmentService : IAppointmentService
 
         if (entity is null) return false;
 
-        // Check overlap only if time or duration changed
+        // Check availability and overlap only if time or duration changed
         if (entity.StartTime != dto.StartTime || entity.DurationMinutes != dto.DurationMinutes)
         {
+            var (isWithin, reason) = await _availabilityService
+                .IsSlotWithinScheduleAsync(entity.NutritionistId, dto.StartTime, dto.DurationMinutes);
+            if (!isWithin)
+                throw new SchedulingConflictException("Outside working hours", reason!);
+
             await CheckOverlapAsync(_dbContext, entity.NutritionistId, dto.StartTime, dto.DurationMinutes, dto.Id);
         }
 

--- a/src/Nutrir.Infrastructure/Services/AvailabilityService.cs
+++ b/src/Nutrir.Infrastructure/Services/AvailabilityService.cs
@@ -255,6 +255,41 @@ public class AvailabilityService : IAvailabilityService
             $"Buffer time set to {minutes} minutes");
     }
 
+    public async Task<(bool IsWithin, string? Reason)> IsSlotWithinScheduleAsync(
+        string practitionerId, DateTime startTimeUtc, int durationMinutes)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync();
+
+        var date = DateOnly.FromDateTime(startTimeUtc);
+        var dayOfWeek = startTimeUtc.DayOfWeek;
+
+        // 1. Check practitioner schedule for the day of week
+        var schedule = await db.PractitionerSchedules
+            .FirstOrDefaultAsync(s => s.UserId == practitionerId && s.DayOfWeek == dayOfWeek);
+
+        if (schedule is null || !schedule.IsAvailable)
+            return (false, $"Practitioner is not available on {dayOfWeek}");
+
+        // 2. Check if appointment falls within working hours
+        var slotStart = TimeOnly.FromDateTime(startTimeUtc);
+        var slotEnd = slotStart.AddMinutes(durationMinutes);
+
+        if (slotStart < schedule.StartTime || slotEnd > schedule.EndTime)
+            return (false, $"Appointment falls outside working hours ({schedule.StartTime}–{schedule.EndTime})");
+
+        // 3. Check for time blocks on the specific date
+        var conflictingBlock = await db.PractitionerTimeBlocks
+            .FirstOrDefaultAsync(tb => tb.UserId == practitionerId
+                                       && tb.Date == date
+                                       && tb.StartTime < slotEnd
+                                       && tb.EndTime > slotStart);
+
+        if (conflictingBlock is not null)
+            return (false, $"Time block conflict: {conflictingBlock.BlockType}");
+
+        return (true, null);
+    }
+
     private static PractitionerTimeBlockDto MapToTimeBlockDto(PractitionerTimeBlock entity) =>
         new(entity.Id, entity.UserId, entity.Date, entity.StartTime, entity.EndTime, entity.BlockType, entity.Notes);
 }


### PR DESCRIPTION
## Summary
- Add `IsSlotWithinScheduleAsync` method to `IAvailabilityService` / `AvailabilityService`
- Inject `IAvailabilityService` into `AppointmentService` and call it in `CreateAsync` and `UpdateAsync`
- Validates against practitioner's weekly schedule (day availability, working hours) and time blocks
- Throws `SchedulingConflictException` for out-of-hours bookings — automatically surfaced by AI tool executor
- `CreateRecurringAsync` inherits the check via `CreateAsync` delegation

Closes #233

## Test plan
- [ ] Book appointment within working hours — should succeed
- [ ] Book appointment at 2 AM when schedule is 9-5 — should fail with descriptive error
- [ ] Book on a day with `IsAvailable = false` — should fail
- [ ] Book during a practitioner time block — should fail
- [ ] Create recurring appointments spanning blocked times — should skip conflicts
- [ ] Verify AI assistant returns readable error for out-of-hours booking

🤖 Generated with [Claude Code](https://claude.com/claude-code)