### PR TITLE
feat: add color-coded macro totals vs targets on meal plan views

### DIFF
--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor
@@ -181,7 +181,21 @@
             <Panel Title="@(day.Label ?? $"Day {day.DayNumber}")" Count="@(day.MealSlots.Count > 0 ? day.MealSlots.Count : null)">
                 <HeaderExtra>
                     <span class="day-totals-header">
-                        @day.TotalCalories.ToString("N0") kcal · @day.TotalProtein.ToString("N0")g P · @day.TotalCarbs.ToString("N0")g C · @day.TotalFat.ToString("N0")g F
+                        <span class="@GetMacroClass(day.TotalCalories, _plan.CalorieTarget)">
+                            @day.TotalCalories.ToString("N0") kcal@(GetMacroDiff(day.TotalCalories, _plan.CalorieTarget, "kcal"))
+                        </span>
+                        ·
+                        <span class="@GetMacroClass(day.TotalProtein, _plan.ProteinTargetG)">
+                            @day.TotalProtein.ToString("N0")g P@(GetMacroDiff(day.TotalProtein, _plan.ProteinTargetG, "g P"))
+                        </span>
+                        ·
+                        <span class="@GetMacroClass(day.TotalCarbs, _plan.CarbsTargetG)">
+                            @day.TotalCarbs.ToString("N0")g C@(GetMacroDiff(day.TotalCarbs, _plan.CarbsTargetG, "g C"))
+                        </span>
+                        ·
+                        <span class="@GetMacroClass(day.TotalFat, _plan.FatTargetG)">
+                            @day.TotalFat.ToString("N0")g F@(GetMacroDiff(day.TotalFat, _plan.FatTargetG, "g F"))
+                        </span>
                     </span>
                 </HeaderExtra>
                 <ChildContent>
@@ -647,6 +661,20 @@
         {
             _isSendingEmail = false;
         }
+    }
+
+    private static string GetMacroClass(decimal actual, decimal? target)
+    {
+        if (!target.HasValue || target.Value == 0) return "";
+        var pct = Math.Abs((actual - target.Value) / target.Value);
+        return pct <= 0.05m ? "on-target" : pct <= 0.10m ? "near-target" : "off-target";
+    }
+
+    private static string GetMacroDiff(decimal actual, decimal? target, string unit)
+    {
+        if (!target.HasValue || target.Value == 0) return "";
+        var diff = actual - target.Value;
+        return $" ({(diff >= 0 ? "+" : "")}{diff.ToString("N0")} {unit})";
     }
 
     private static BadgeVariant GetStatusVariant(MealPlanStatus status) => status switch

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor.css
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanDetail.razor.css
@@ -251,6 +251,22 @@
     line-height: 1.6;
 }
 
+/* ── Macro Target Comparison Indicators ──────────────── */
+.on-target {
+    color: var(--color-success);
+    font-weight: 600;
+}
+
+.near-target {
+    color: var(--color-warning, #d97706);
+    font-weight: 600;
+}
+
+.off-target {
+    color: var(--color-error);
+    font-weight: 600;
+}
+
 /* ── Day Panel Meal Slot Sections ────────────────────── */
 .slot-section {
     border-bottom: 1px solid rgba(var(--rgb-accent), 0.08);

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor
@@ -80,17 +80,18 @@
             <!-- Day Summary Bar -->
             <div class="day-totals @GetDayTotalsClass(currentDay)">
                 <span class="totals-label">Day Total:</span>
-                <span>@GetDayCalories(currentDay).ToString("N0") kcal</span>
-                <span>· @GetDayProtein(currentDay).ToString("N0")g P</span>
-                <span>· @GetDayCarbs(currentDay).ToString("N0")g C</span>
-                <span>· @GetDayFat(currentDay).ToString("N0")g F</span>
-                @if (_plan.CalorieTarget.HasValue)
-                {
-                    var diff = GetDayCalories(currentDay) - _plan.CalorieTarget.Value;
-                    <span class="target-diff @(diff > 50 ? "over" : diff < -50 ? "under" : "on-target")">
-                        (@(diff >= 0 ? "+" : "")@diff.ToString("N0") kcal)
-                    </span>
-                }
+                <span class="@GetMacroClass(GetDayCalories(currentDay), _plan.CalorieTarget)">
+                    @GetDayCalories(currentDay).ToString("N0") kcal@(GetMacroDiff(GetDayCalories(currentDay), _plan.CalorieTarget, "kcal"))
+                </span>
+                <span class="@GetMacroClass(GetDayProtein(currentDay), _plan.ProteinTargetG)">
+                    · @GetDayProtein(currentDay).ToString("N0")g P@(GetMacroDiff(GetDayProtein(currentDay), _plan.ProteinTargetG, "g P"))
+                </span>
+                <span class="@GetMacroClass(GetDayCarbs(currentDay), _plan.CarbsTargetG)">
+                    · @GetDayCarbs(currentDay).ToString("N0")g C@(GetMacroDiff(GetDayCarbs(currentDay), _plan.CarbsTargetG, "g C"))
+                </span>
+                <span class="@GetMacroClass(GetDayFat(currentDay), _plan.FatTargetG)">
+                    · @GetDayFat(currentDay).ToString("N0")g F@(GetMacroDiff(GetDayFat(currentDay), _plan.FatTargetG, "g F"))
+                </span>
             </div>
 
             <!-- Meal Slots -->
@@ -445,11 +446,23 @@
 
     private string GetDayTotalsClass(EditDay day)
     {
-        if (_plan?.CalorieTarget is null) return "";
-        var diff = GetDayCalories(day) - _plan.CalorieTarget.Value;
-        if (diff > 100) return "over";
-        if (diff < -100) return "under";
-        return "on-target";
+        if (_plan?.CalorieTarget is null || _plan.CalorieTarget.Value == 0) return "";
+        var pct = Math.Abs((GetDayCalories(day) - _plan.CalorieTarget.Value) / _plan.CalorieTarget.Value);
+        return pct <= 0.05m ? "on-target" : pct <= 0.10m ? "near-target" : "off-target";
+    }
+
+    private static string GetMacroClass(decimal actual, decimal? target)
+    {
+        if (!target.HasValue || target.Value == 0) return "";
+        var pct = Math.Abs((actual - target.Value) / target.Value);
+        return pct <= 0.05m ? "on-target" : pct <= 0.10m ? "near-target" : "off-target";
+    }
+
+    private static string GetMacroDiff(decimal actual, decimal? target, string unit)
+    {
+        if (!target.HasValue || target.Value == 0) return "";
+        var diff = actual - target.Value;
+        return $" ({(diff >= 0 ? "+" : "")}{diff.ToString("N0")} {unit})";
     }
 
     private static string FormatMealType(MealType type) => type switch

--- a/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor.css
+++ b/src/Nutrir.Web/Components/Pages/MealPlans/MealPlanEdit.razor.css
@@ -155,14 +155,14 @@
     background: rgba(90, 158, 107, 0.05);
 }
 
-.day-totals.over {
-    border-color: var(--color-warning);
+.day-totals.near-target {
+    border-color: var(--color-warning, #d97706);
     background: rgba(196, 136, 47, 0.05);
 }
 
-.day-totals.under {
-    border-color: var(--color-info);
-    background: rgba(74, 126, 139, 0.05);
+.day-totals.off-target {
+    border-color: var(--color-error);
+    background: rgba(220, 38, 38, 0.05);
 }
 
 .totals-label {
@@ -173,21 +173,20 @@
     color: var(--color-text-muted);
 }
 
-.target-diff {
-    font-weight: 600;
-    font-size: var(--text-xs);
-}
-
-.target-diff.over {
-    color: var(--color-warning);
-}
-
-.target-diff.under {
-    color: var(--color-info);
-}
-
-.target-diff.on-target {
+/* ── Macro Target Comparison Indicators ──────────────── */
+.on-target {
     color: var(--color-success);
+    font-weight: 600;
+}
+
+.near-target {
+    color: var(--color-warning, #d97706);
+    font-weight: 600;
+}
+
+.off-target {
+    color: var(--color-error);
+    font-weight: 600;
 }
 
 /* ── Slot Card ───────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Both meal plan detail and edit views now show color-coded comparison of actual macro totals against plan targets
- Uses percentage-based thresholds: green (within 5%), amber (within 10%), red (>10% off)
- Applied to all four macros: calories, protein, carbs, fat
- Replaces the edit page's previous flat ±50 kcal threshold with consistent percentage approach
- Days with no items show 0 with appropriate off-target styling

Closes #234

## Test plan
- [ ] Create meal plan with targets, add items — verify totals update on edit page with color indicators
- [ ] View same plan on detail page — verify totals match with same color coding
- [ ] Test thresholds: exactly at target (green), 7% off (amber), 15% off (red)
- [ ] Verify days with no items show 0 / target with red indicator
- [ ] Verify plan with no targets set shows totals without color coding

🤖 Generated with [Claude Code](https://claude.com/claude-code)