### PR TITLE
Fix oversized empty state icon on appointments list

### DIFF
--- a/src/Nutrir.Web/Components/Pages/Appointments/AppointmentList.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Appointments/AppointmentList.razor.css
@@ -241,3 +241,31 @@
         flex: 1;
     }
 }
+
+/* ── Empty State ─────────────────────────────────────── */
+.empty-state {
+    padding: var(--space-16) var(--space-6);
+    text-align: center;
+}
+
+.empty-state-icon {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto var(--space-4);
+    color: var(--color-accent);
+}
+
+.empty-state-title {
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: var(--space-2);
+}
+
+.empty-state-desc {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    max-width: 320px;
+    margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- Adds scoped empty state CSS to `AppointmentList.razor.css` to fix the oversized calendar icon
- The `empty-state-icon` class was defined in `DataGrid.razor.css` (scoped), but Blazor CSS isolation prevents it from applying to content projected via `EmptyContent` render fragments
- Constrains the SVG to the intended 64x64px

Closes #265

## Test plan
- [ ] Navigate to Appointments list view with no appointments in the current date range
- [ ] Verify the empty state icon renders at 64x64px, not fullscreen
- [ ] Verify the "No appointments found" text and description are properly centered below the icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)