### PR TITLE
Improve calendar view spacing, legibility, and pill layout

### DIFF
--- a/src/Nutrir.Infrastructure/Services/CalendarService.cs
+++ b/src/Nutrir.Infrastructure/Services/CalendarService.cs
@@ -47,7 +47,7 @@ public class CalendarService : ICalendarService
             .Where(a => a.StartTime.AddMinutes(a.DurationMinutes) > start)
             .Select(a => new CalendarAppointmentDto(
                 a.Id,
-                a.ClientName,
+                $"{a.StartTime:h:mm tt} · {a.ClientName}",
                 a.StartTime,
                 a.StartTime.AddMinutes(a.DurationMinutes),
                 a.Type,

--- a/src/Nutrir.Web/Components/Pages/Appointments/AppointmentCalendar.razor
+++ b/src/Nutrir.Web/Components/Pages/Appointments/AppointmentCalendar.razor
@@ -157,11 +157,15 @@
 
         args.Attributes["style"] = args.Data.Type switch
         {
-            AppointmentType.InitialConsultation => $"background: color-mix(in srgb, var(--color-primary) 12%, transparent); border-left: 3px solid var(--color-primary); color: var(--color-text);{cancelledStyle}",
-            AppointmentType.FollowUp => $"background: color-mix(in srgb, var(--color-secondary) 12%, transparent); border-left: 3px solid var(--color-secondary); color: var(--color-text);{cancelledStyle}",
-            AppointmentType.CheckIn => $"background: color-mix(in srgb, var(--color-info) 12%, transparent); border-left: 3px solid var(--color-info); color: var(--color-text);{cancelledStyle}",
-            _ => $"background: color-mix(in srgb, var(--color-primary) 12%, transparent); border-left: 3px solid var(--color-primary); color: var(--color-text);{cancelledStyle}"
+            AppointmentType.InitialConsultation => $"background: color-mix(in srgb, var(--color-primary) 20%, transparent); border-left: 3px solid var(--color-primary); color: var(--color-text);{cancelledStyle}",
+            AppointmentType.FollowUp => $"background: color-mix(in srgb, var(--color-secondary) 20%, transparent); border-left: 3px solid var(--color-secondary); color: var(--color-text);{cancelledStyle}",
+            AppointmentType.CheckIn => $"background: color-mix(in srgb, var(--color-info) 20%, transparent); border-left: 3px solid var(--color-info); color: var(--color-text);{cancelledStyle}",
+            _ => $"background: color-mix(in srgb, var(--color-primary) 20%, transparent); border-left: 3px solid var(--color-primary); color: var(--color-text);{cancelledStyle}"
         };
+
+        // Expose local time as a data attribute so it can be read by custom templates or CSS
+        var localStart = TimeZoneService.ToUserLocal(args.Data.StartTime);
+        args.Attributes["data-appt-time"] = localStart.ToString("h:mm tt");
     }
 
     private void OnJumpDateChanged(ChangeEventArgs e)

--- a/src/Nutrir.Web/Components/Pages/Appointments/AppointmentCalendar.razor.css
+++ b/src/Nutrir.Web/Components/Pages/Appointments/AppointmentCalendar.razor.css
@@ -107,7 +107,7 @@
 
 /* ── Calendar Container ──────────────────────────────── */
 .calendar-container {
-    --calendar-height: 700px;
+    --calendar-height: 800px;
     background: var(--color-bg-card);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
@@ -192,11 +192,14 @@
 }
 
 /* ── Today Highlight ─────────────────────────────────── */
-::deep .rz-today {
-    background: var(--color-primary-muted);
+::deep .rz-today,
+::deep .rz-scheduler .rz-today,
+::deep .rz-scheduler .rz-view td.rz-today {
+    background: var(--color-primary-muted) !important;
 }
 
-::deep .rz-today .rz-cell-text {
+::deep .rz-today .rz-cell-text,
+::deep .rz-scheduler .rz-today .rz-cell-text {
     background: var(--color-primary);
     color: var(--color-text-on-primary);
     border-radius: 50%;
@@ -234,12 +237,13 @@
 /* ── Event Styling ───────────────────────────────────── */
 ::deep .rz-event {
     border-radius: var(--radius-sm);
-    font-size: var(--text-xs);
+    font-size: var(--text-sm);
     font-weight: 500;
     border: none;
     cursor: pointer;
     transition: all var(--duration-fast) var(--ease-default);
-    margin-bottom: 2px;
+    margin-bottom: 3px;
+    min-height: 36px;
 }
 
 ::deep .rz-event:hover {
@@ -248,7 +252,32 @@
 }
 
 ::deep .rz-event .rz-event-content {
-    padding: var(--space-1) var(--space-2);
+    padding: var(--space-2) var(--space-2);
+    line-height: var(--leading-snug);
+    overflow: hidden;
+}
+
+::deep .rz-event .rz-event-content > * {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: block;
+}
+
+/* Time line shown above the client name in pills */
+::deep .rz-event .appointment-time {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    opacity: 0.75;
+    margin-bottom: 1px;
+}
+
+::deep .rz-event .appointment-title {
+    font-size: var(--text-sm);
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* ── Header Cells ────────────────────────────────────── */
@@ -278,7 +307,7 @@
 /* ── Weekend Columns ─────────────────────────────────── */
 ::deep .rz-scheduler td:nth-child(1),
 ::deep .rz-scheduler td:nth-child(7) {
-    background: rgba(0, 0, 0, 0.015);
+    background: rgba(0, 0, 0, 0.035);
 }
 
 /* ── Other Month Days ────────────────────────────────── */
@@ -313,7 +342,7 @@
     }
 
     .calendar-container {
-        --calendar-height: 600px;
+        --calendar-height: 680px;
     }
 }
 


### PR DESCRIPTION
## Summary
- Show appointment time alongside client name in calendar pills (e.g., "9:00 AM · John Smith")
- Increase color-mix opacity from 12% to 20% for better type color distinction
- Increase calendar height from 700px to 800px to give day cells more room
- Bump event pill font size, padding, and min-height for readability
- Add text-overflow ellipsis to prevent cramped/clipped text
- Strengthen weekend column shading (0.015 → 0.035 opacity)
- Harden today highlight selectors with higher specificity

Closes #266

## Test plan
- [ ] Navigate to Appointments → Calendar (month view)
- [ ] Verify appointment pills show time + client name
- [ ] Verify pills have readable text with proper spacing
- [ ] Verify appointment type colors (Initial, Follow-Up, Check-In) are visually distinct
- [ ] Verify today's date cell has a visible highlight
- [ ] Verify weekend columns have subtle but visible shading
- [ ] Check tablet (≤860px) and mobile (≤600px) responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)