### PR TITLE
test: add unit tests for IntakeFormService workflow

### DIFF
--- a/tests/Nutrir.Tests.Unit/Services/IntakeFormServiceTests.cs
+++ b/tests/Nutrir.Tests.Unit/Services/IntakeFormServiceTests.cs
@@ -575,7 +575,8 @@ public class IntakeFormServiceTests : IDisposable
         var result = await _sut.ListFormsAsync(IntakeFormStatus.Submitted);
 
         // Assert
-        result.Should().OnlyContain(f => f.Status == IntakeFormStatus.Submitted,
+        result.Where(f => f.ClientEmail == TestEmail)
+            .Should().OnlyContain(f => f.Status == IntakeFormStatus.Submitted,
             because: "the status filter must exclude forms with a different status");
     }
 
@@ -948,6 +949,7 @@ public class IntakeFormServiceTests : IDisposable
 
         // Assert
         success.Should().BeFalse();
+        clientId.Should().BeNull();
         error.Should().Contain("submitted");
     }
 


### PR DESCRIPTION
## Summary
- Add 67 unit tests for `IntakeFormService` covering all 6 public methods
- Tests cover form creation, token/ID lookups, listing with filters, submission workflow (including expiry and resubmission rejection), and review workflow (client creation, personal info mapping, health profile sub-entities, consent handling, notes aggregation)
- Follows existing test conventions: SQLite in-memory DB, NSubstitute mocks, FluentAssertions

Closes #281

## Test plan
- [x] All 67 tests pass locally
- [x] Tests cover all scenarios from issue requirements
- [x] Follows patterns from existing service test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)