### PR TITLE
test: add unit tests for CalendarService and ReportService

### DIFF
--- a/tests/Nutrir.Tests.Unit/Services/CalendarServiceTests.cs
+++ b/tests/Nutrir.Tests.Unit/Services/CalendarServiceTests.cs
@@ -1,0 +1,420 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nutrir.Core.Entities;
+using Nutrir.Core.Enums;
+using Nutrir.Infrastructure.Data;
+using Nutrir.Infrastructure.Services;
+using Nutrir.Tests.Unit.Helpers;
+using Xunit;
+
+namespace Nutrir.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for CalendarService.GetAppointmentsByDateRangeAsync.
+///
+/// Key behaviours under test:
+///   - Appointments whose computed end time (StartTime + DurationMinutes) falls within
+///     the requested range are returned.
+///   - Appointments completely outside the range (both start and end before or after) are excluded.
+///   - The 90-minute look-back buffer allows appointments that started before the range
+///     but are still running at range-start to be returned.
+///   - Soft-deleted appointments are always excluded.
+///   - An empty range (no qualifying appointments) returns an empty list.
+///   - The returned title is formatted as "h:mm tt · FirstName LastName".
+/// </summary>
+public class CalendarServiceTests : IDisposable
+{
+    // ---------------------------------------------------------------------------
+    // Infrastructure
+    // ---------------------------------------------------------------------------
+
+    private readonly AppDbContext _dbContext;
+    private readonly SqliteConnection _connection;
+    private readonly CalendarService _sut;
+
+    private const string NutritionistId = "nutritionist-calendar-test-001";
+
+    private int _clientId;
+
+    public CalendarServiceTests()
+    {
+        (_dbContext, _connection) = TestDbContextFactory.Create();
+
+        var dbContextFactory = new SharedConnectionContextFactory(_connection);
+
+        _sut = new CalendarService(
+            dbContextFactory,
+            NullLogger<CalendarService>.Instance);
+
+        SeedData();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Seed helpers
+    // ---------------------------------------------------------------------------
+
+    private void SeedData()
+    {
+        var nutritionist = new ApplicationUser
+        {
+            Id = NutritionistId,
+            UserName = "nutritionist@calendartest.com",
+            NormalizedUserName = "NUTRITIONIST@CALENDARTEST.COM",
+            Email = "nutritionist@calendartest.com",
+            NormalizedEmail = "NUTRITIONIST@CALENDARTEST.COM",
+            FirstName = "Jane",
+            LastName = "Doe",
+            DisplayName = "Jane Doe",
+            CreatedDate = DateTime.UtcNow
+        };
+
+        var client = new Client
+        {
+            FirstName = "Alice",
+            LastName = "Calendar",
+            PrimaryNutritionistId = NutritionistId,
+            ConsentGiven = true,
+            ConsentTimestamp = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        _dbContext.Users.Add(nutritionist);
+        _dbContext.Clients.Add(client);
+        _dbContext.SaveChanges();
+
+        _clientId = client.Id;
+    }
+
+    /// <summary>
+    /// Inserts an Appointment directly into the database, bypassing any service logic.
+    /// </summary>
+    private Appointment SeedAppointment(
+        DateTime startTime,
+        int durationMinutes = 60,
+        AppointmentType type = AppointmentType.FollowUp,
+        AppointmentStatus status = AppointmentStatus.Scheduled,
+        bool isDeleted = false)
+    {
+        var appointment = new Appointment
+        {
+            ClientId = _clientId,
+            NutritionistId = NutritionistId,
+            Type = type,
+            Status = status,
+            StartTime = startTime,
+            DurationMinutes = durationMinutes,
+            Location = AppointmentLocation.Virtual,
+            IsDeleted = isDeleted,
+            DeletedAt = isDeleted ? DateTime.UtcNow : null,
+            CreatedAt = DateTime.UtcNow
+        };
+        _dbContext.Appointments.Add(appointment);
+        _dbContext.SaveChanges();
+        return appointment;
+    }
+
+    // ---------------------------------------------------------------------------
+    // GetAppointmentsByDateRangeAsync — appointments within range
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_WithAppointmentsInRange_ReturnsMatching()
+    {
+        // Arrange
+        var rangeStart = new DateTime(2025, 6, 10, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 6, 10, 17, 0, 0, DateTimeKind.Utc);
+
+        SeedAppointment(new DateTime(2025, 6, 10, 10, 0, 0, DateTimeKind.Utc), durationMinutes: 60);
+        SeedAppointment(new DateTime(2025, 6, 10, 14, 0, 0, DateTimeKind.Utc), durationMinutes: 30);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().HaveCount(2, because: "both appointments start and end within the requested range");
+    }
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_WithAppointmentsInRange_ReturnsCorrectIds()
+    {
+        // Arrange
+        var rangeStart = new DateTime(2025, 6, 11, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 6, 11, 17, 0, 0, DateTimeKind.Utc);
+
+        var inRange = SeedAppointment(new DateTime(2025, 6, 11, 11, 0, 0, DateTimeKind.Utc));
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().ContainSingle(r => r.Id == inRange.Id);
+    }
+
+    // ---------------------------------------------------------------------------
+    // GetAppointmentsByDateRangeAsync — appointments outside range
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_ExcludesOutsideRange()
+    {
+        // Arrange
+        var rangeStart = new DateTime(2025, 6, 15, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 6, 15, 17, 0, 0, DateTimeKind.Utc);
+
+        // Ends before range start — completely before
+        SeedAppointment(new DateTime(2025, 6, 15, 7, 0, 0, DateTimeKind.Utc), durationMinutes: 30);
+
+        // Starts after range end — completely after
+        SeedAppointment(new DateTime(2025, 6, 15, 18, 0, 0, DateTimeKind.Utc), durationMinutes: 60);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().BeEmpty(because: "neither appointment overlaps the requested range");
+    }
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_ExcludesAppointmentEndingExactlyAtRangeStart()
+    {
+        // Arrange — a 60-minute appointment ending exactly at rangeStart does not overlap.
+        var rangeStart = new DateTime(2025, 6, 16, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 6, 16, 17, 0, 0, DateTimeKind.Utc);
+
+        // StartTime = 08:00, Duration = 60 min → EndTime = 09:00 == rangeStart (not > rangeStart)
+        SeedAppointment(new DateTime(2025, 6, 16, 8, 0, 0, DateTimeKind.Utc), durationMinutes: 60);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().BeEmpty(
+            because: "an appointment whose EndTime equals rangeStart does not satisfy EndTime > rangeStart");
+    }
+
+    // ---------------------------------------------------------------------------
+    // GetAppointmentsByDateRangeAsync — 90-minute buffer overlap
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_IncludesOverlappingAppointment()
+    {
+        // Arrange — appointment starts 60 minutes before rangeStart but its 90-minute
+        // duration means it is still running when the range opens. The 90-min buffer
+        // ensures the query fetches it so the in-memory filter can include it.
+        var rangeStart = new DateTime(2025, 6, 20, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 6, 20, 17, 0, 0, DateTimeKind.Utc);
+
+        // StartTime = 08:00, Duration = 90 min → EndTime = 09:30 > rangeStart (09:00)
+        var overlapping = SeedAppointment(
+            new DateTime(2025, 6, 20, 8, 0, 0, DateTimeKind.Utc),
+            durationMinutes: 90);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().ContainSingle(r => r.Id == overlapping.Id,
+            because: "the appointment ends after rangeStart so it overlaps the requested window");
+    }
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_ExcludesAppointmentBeyondBuffer()
+    {
+        // Arrange — appointment starts more than 90 minutes before rangeStart AND ends
+        // before rangeStart, so it falls outside even the buffered query window.
+        var rangeStart = new DateTime(2025, 6, 21, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 6, 21, 17, 0, 0, DateTimeKind.Utc);
+
+        // StartTime = 07:00 (120 min before rangeStart), Duration = 60 min → EndTime = 08:00
+        // bufferStart = rangeStart - 90 min = 07:30 → StartTime (07:00) < bufferStart, excluded by DB query
+        SeedAppointment(
+            new DateTime(2025, 6, 21, 7, 0, 0, DateTimeKind.Utc),
+            durationMinutes: 60);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().BeEmpty(
+            because: "the appointment started more than 90 minutes before the range and ended before it");
+    }
+
+    // ---------------------------------------------------------------------------
+    // GetAppointmentsByDateRangeAsync — soft-deleted exclusion
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_ExcludesSoftDeleted()
+    {
+        // Arrange
+        var rangeStart = new DateTime(2025, 7, 1, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 7, 1, 17, 0, 0, DateTimeKind.Utc);
+
+        var active  = SeedAppointment(new DateTime(2025, 7, 1, 10, 0, 0, DateTimeKind.Utc), isDeleted: false);
+        var deleted = SeedAppointment(new DateTime(2025, 7, 1, 11, 0, 0, DateTimeKind.Utc), isDeleted: true);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().ContainSingle(r => r.Id == active.Id,
+            because: "only the non-deleted appointment should be returned");
+        results.Should().NotContain(r => r.Id == deleted.Id,
+            because: "soft-deleted appointments must be excluded by the IsDeleted filter");
+    }
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_AllSoftDeleted_ReturnsEmpty()
+    {
+        // Arrange
+        var rangeStart = new DateTime(2025, 7, 2, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 7, 2, 17, 0, 0, DateTimeKind.Utc);
+
+        SeedAppointment(new DateTime(2025, 7, 2, 10, 0, 0, DateTimeKind.Utc), isDeleted: true);
+        SeedAppointment(new DateTime(2025, 7, 2, 12, 0, 0, DateTimeKind.Utc), isDeleted: true);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().BeEmpty(because: "all seeded appointments are soft-deleted");
+    }
+
+    // ---------------------------------------------------------------------------
+    // GetAppointmentsByDateRangeAsync — empty range
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_EmptyRange_ReturnsEmptyList()
+    {
+        // Arrange — use a date range with no seeded appointments
+        var rangeStart = new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2030, 1, 1, 23, 59, 59, DateTimeKind.Utc);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().BeEmpty(because: "no appointments exist within the given date range");
+    }
+
+    // ---------------------------------------------------------------------------
+    // GetAppointmentsByDateRangeAsync — title format
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_FormatsTitle()
+    {
+        // Arrange — use a fixed time that has a predictable "h:mm tt" representation
+        // 02:30 PM → "2:30 PM"
+        var startTime  = new DateTime(2025, 8, 5, 14, 30, 0, DateTimeKind.Utc);
+        var rangeStart = new DateTime(2025, 8, 5, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 8, 5, 17, 0, 0, DateTimeKind.Utc);
+
+        SeedAppointment(startTime);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().ContainSingle();
+        var expectedTitle = $"{startTime:h:mm tt} · Alice Calendar";
+        results[0].Title.Should().Be(expectedTitle,
+            because: "the title must follow the 'h:mm tt · FirstName LastName' pattern");
+    }
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_FormatsTitle_MidnightHour()
+    {
+        // Arrange — 12:00 AM uses "12:00 AM" in h:mm tt format
+        var startTime  = new DateTime(2025, 8, 6, 0, 0, 0, DateTimeKind.Utc);
+        var rangeStart = new DateTime(2025, 8, 5, 23, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 8, 6, 2, 0, 0, DateTimeKind.Utc);
+
+        SeedAppointment(startTime);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().ContainSingle();
+        var expectedTitle = $"{startTime:h:mm tt} · Alice Calendar";
+        results[0].Title.Should().Be(expectedTitle,
+            because: "midnight should render as '12:00 AM' in the h:mm tt format");
+    }
+
+    // ---------------------------------------------------------------------------
+    // GetAppointmentsByDateRangeAsync — DTO field mapping
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_WithAppointmentsInRange_MapsStartTimeCorrectly()
+    {
+        // Arrange
+        var startTime  = new DateTime(2025, 9, 1, 10, 0, 0, DateTimeKind.Utc);
+        var rangeStart = new DateTime(2025, 9, 1, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 9, 1, 17, 0, 0, DateTimeKind.Utc);
+
+        SeedAppointment(startTime, durationMinutes: 60);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().ContainSingle();
+        results[0].StartTime.Should().Be(startTime);
+    }
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_WithAppointmentsInRange_MapsEndTimeCorrectly()
+    {
+        // Arrange
+        var startTime    = new DateTime(2025, 9, 2, 10, 0, 0, DateTimeKind.Utc);
+        var expectedEnd  = startTime.AddMinutes(45);
+        var rangeStart   = new DateTime(2025, 9, 2, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd     = new DateTime(2025, 9, 2, 17, 0, 0, DateTimeKind.Utc);
+
+        SeedAppointment(startTime, durationMinutes: 45);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().ContainSingle();
+        results[0].EndTime.Should().Be(expectedEnd,
+            because: "EndTime should equal StartTime plus DurationMinutes");
+    }
+
+    [Fact]
+    public async Task GetAppointmentsByDateRangeAsync_WithAppointmentsInRange_MapsTypeAndStatus()
+    {
+        // Arrange
+        var startTime  = new DateTime(2025, 9, 3, 10, 0, 0, DateTimeKind.Utc);
+        var rangeStart = new DateTime(2025, 9, 3, 9, 0, 0, DateTimeKind.Utc);
+        var rangeEnd   = new DateTime(2025, 9, 3, 17, 0, 0, DateTimeKind.Utc);
+
+        SeedAppointment(startTime,
+            type: AppointmentType.InitialConsultation,
+            status: AppointmentStatus.Confirmed);
+
+        // Act
+        var results = await _sut.GetAppointmentsByDateRangeAsync(rangeStart, rangeEnd);
+
+        // Assert
+        results.Should().ContainSingle();
+        results[0].Type.Should().Be(AppointmentType.InitialConsultation);
+        results[0].Status.Should().Be(AppointmentStatus.Confirmed);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Cleanup
+    // ---------------------------------------------------------------------------
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _connection.Dispose();
+    }
+}

--- a/tests/Nutrir.Tests.Unit/Services/ReportServiceTests.cs
+++ b/tests/Nutrir.Tests.Unit/Services/ReportServiceTests.cs
@@ -1,0 +1,465 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nutrir.Core.Entities;
+using Nutrir.Core.Enums;
+using Nutrir.Infrastructure.Data;
+using Nutrir.Infrastructure.Services;
+using Nutrir.Tests.Unit.Helpers;
+using Xunit;
+
+namespace Nutrir.Tests.Unit.Services;
+
+public class ReportServiceTests : IDisposable
+{
+    // ---------------------------------------------------------------------------
+    // Infrastructure
+    // ---------------------------------------------------------------------------
+
+    private readonly AppDbContext _dbContext;
+    private readonly SqliteConnection _connection;
+    private readonly SharedConnectionContextFactory _dbContextFactory;
+
+    private readonly ReportService _sut;
+
+    private const string NutritionistId = "nutritionist-report-test-001";
+
+    // Captured after SaveChanges so tests do not hard-code magic numbers.
+    private int _clientOldId;   // created before the report window
+    private int _clientNewId;   // created inside the report window
+    private int _clientExtra1Id;
+    private int _clientExtra2Id;
+
+    // Fixed reference window used by most tests.
+    // Range is exactly 30 days → weekly bucketing branch.
+    private static readonly DateTime WindowStart = new(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime WindowEnd   = new(2025, 3, 31, 0, 0, 0, DateTimeKind.Utc);
+
+    public ReportServiceTests()
+    {
+        (_dbContext, _connection) = TestDbContextFactory.Create();
+        _dbContextFactory = new SharedConnectionContextFactory(_connection);
+
+        _sut = new ReportService(_dbContextFactory, NullLogger<ReportService>.Instance);
+
+        SeedData();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Seed helpers
+    // ---------------------------------------------------------------------------
+
+    private void SeedData()
+    {
+        var nutritionist = new ApplicationUser
+        {
+            Id = NutritionistId,
+            UserName = "nutritionist@reporttest.com",
+            NormalizedUserName = "NUTRITIONIST@REPORTTEST.COM",
+            Email = "nutritionist@reporttest.com",
+            NormalizedEmail = "NUTRITIONIST@REPORTTEST.COM",
+            FirstName = "Jane",
+            LastName = "Report",
+            DisplayName = "Jane Report",
+            CreatedDate = DateTime.UtcNow
+        };
+
+        // clientOld — created BEFORE the window; represents a returning client
+        var clientOld = new Client
+        {
+            FirstName = "Old",
+            LastName = "Client",
+            PrimaryNutritionistId = NutritionistId,
+            ConsentGiven = true,
+            EmailRemindersEnabled = true,
+            CreatedAt = new DateTime(2024, 12, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        // clientNew — created INSIDE the window; represents a new client
+        var clientNew = new Client
+        {
+            FirstName = "New",
+            LastName = "Client",
+            PrimaryNutritionistId = NutritionistId,
+            ConsentGiven = true,
+            EmailRemindersEnabled = true,
+            CreatedAt = new DateTime(2025, 3, 5, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        // Two extra clients for variety in type-grouping and active-client tests
+        var clientExtra1 = new Client
+        {
+            FirstName = "Extra",
+            LastName = "One",
+            PrimaryNutritionistId = NutritionistId,
+            ConsentGiven = true,
+            EmailRemindersEnabled = false,
+            CreatedAt = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var clientExtra2 = new Client
+        {
+            FirstName = "Extra",
+            LastName = "Two",
+            PrimaryNutritionistId = NutritionistId,
+            ConsentGiven = true,
+            EmailRemindersEnabled = false,
+            CreatedAt = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        _dbContext.Users.Add(nutritionist);
+        _dbContext.Clients.AddRange(clientOld, clientNew, clientExtra1, clientExtra2);
+        _dbContext.SaveChanges();
+
+        _clientOldId    = clientOld.Id;
+        _clientNewId    = clientNew.Id;
+        _clientExtra1Id = clientExtra1.Id;
+        _clientExtra2Id = clientExtra2.Id;
+
+        // Seed appointments inside the window
+        var appointments = new List<Appointment>
+        {
+            // Completed — for clientOld (returning) and clientNew (new)
+            MakeAppointment(_clientOldId, AppointmentStatus.Completed, AppointmentType.FollowUp,
+                new DateTime(2025, 3, 3, 10, 0, 0, DateTimeKind.Utc)),
+            MakeAppointment(_clientNewId, AppointmentStatus.Completed, AppointmentType.InitialConsultation,
+                new DateTime(2025, 3, 6, 10, 0, 0, DateTimeKind.Utc)),
+            MakeAppointment(_clientExtra1Id, AppointmentStatus.Completed, AppointmentType.FollowUp,
+                new DateTime(2025, 3, 10, 10, 0, 0, DateTimeKind.Utc)),
+
+            // NoShow
+            MakeAppointment(_clientExtra2Id, AppointmentStatus.NoShow, AppointmentType.CheckIn,
+                new DateTime(2025, 3, 12, 9, 0, 0, DateTimeKind.Utc)),
+
+            // Cancelled
+            MakeAppointment(_clientExtra1Id, AppointmentStatus.Cancelled, AppointmentType.CheckIn,
+                new DateTime(2025, 3, 15, 9, 0, 0, DateTimeKind.Utc)),
+
+            // LateCancellation
+            MakeAppointment(_clientExtra2Id, AppointmentStatus.LateCancellation, AppointmentType.FollowUp,
+                new DateTime(2025, 3, 20, 9, 0, 0, DateTimeKind.Utc)),
+
+            // Scheduled (in range but not Completed/NoShow/Cancelled — counts toward active clients)
+            MakeAppointment(_clientOldId, AppointmentStatus.Scheduled, AppointmentType.CheckIn,
+                new DateTime(2025, 3, 25, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        _dbContext.Appointments.AddRange(appointments);
+        _dbContext.SaveChanges();
+    }
+
+    private Appointment MakeAppointment(int clientId, AppointmentStatus status, AppointmentType type, DateTime startTime) =>
+        new()
+        {
+            ClientId        = clientId,
+            NutritionistId  = NutritionistId,
+            Type            = type,
+            Status          = status,
+            StartTime       = startTime,
+            DurationMinutes = 60,
+            CreatedAt       = DateTime.UtcNow
+        };
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _connection.Dispose();
+    }
+
+    // ---------------------------------------------------------------------------
+    // ── GetPracticeSummaryAsync: Aggregation ──
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_CorrectlyCountsTotalVisits_OnlyCompletedAppointmentsCount()
+    {
+        // Arrange: seeded data has 3 Completed appointments in the window.
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(WindowStart, WindowEnd);
+
+        // Assert
+        result.TotalVisits.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_CorrectlyCountsNewClients_ClientsCreatedWithinRange()
+    {
+        // Arrange: only clientNew was created inside the window (2025-03-05).
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(WindowStart, WindowEnd);
+
+        // Assert
+        result.NewClients.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_CorrectlyCountsReturningClients_ClientsCreatedBeforeRangeWithCompletedAppointments()
+    {
+        // Arrange: clientOld (created 2024-12-01) and clientExtra1 (created 2024-06-01)
+        // both have Completed appointments inside the window → 2 returning clients.
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(WindowStart, WindowEnd);
+
+        // Assert
+        result.ReturningClients.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_CorrectlyCountsNoShows_CountAndRateAreAccurate()
+    {
+        // Arrange: 1 NoShow out of 7 total appointments in window.
+        // Expected rate = round(1/7 * 100, 1) = 14.3%
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(WindowStart, WindowEnd);
+
+        // Assert
+        result.NoShowCount.Should().Be(1);
+        result.NoShowRate.Should().Be(Math.Round(1m / 7m * 100m, 1));
+    }
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_CorrectlyCountsCancellations_BothCancelledAndLateCancellationIncluded()
+    {
+        // Arrange: 1 Cancelled + 1 LateCancellation = 2 cancellations out of 7 total.
+        // Expected rate = round(2/7 * 100, 1) = 28.6%
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(WindowStart, WindowEnd);
+
+        // Assert
+        result.CancellationCount.Should().Be(2);
+        result.CancellationRate.Should().Be(Math.Round(2m / 7m * 100m, 1));
+    }
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_CorrectlyCountsActiveClients_DistinctClientsWithNonCancelledAppointments()
+    {
+        // Arrange:
+        // Completed  → clientOld, clientNew, clientExtra1
+        // NoShow     → clientExtra2
+        // Scheduled  → clientOld  (duplicate, still counted once)
+        // Cancelled  → clientExtra1  (excluded)
+        // LateCancellation → clientExtra2  (excluded)
+        //
+        // Non-cancelled statuses: Completed (3), NoShow (1), Scheduled (1)
+        // Distinct client IDs with at least one non-cancelled appointment:
+        //   clientOld, clientNew, clientExtra1, clientExtra2 → 4
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(WindowStart, WindowEnd);
+
+        // Assert
+        result.ActiveClients.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_GroupsAppointmentsByType_OrderedByCountDescending()
+    {
+        // Arrange:
+        // FollowUp            → 3 (clientOld Completed, clientExtra1 Completed, clientExtra2 LateCancellation)
+        // CheckIn             → 3 (clientExtra2 NoShow, clientExtra1 Cancelled, clientOld Scheduled)
+        // InitialConsultation → 1 (clientNew Completed)
+        //
+        // FollowUp and CheckIn are tied at 3; InitialConsultation is last at 1.
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(WindowStart, WindowEnd);
+
+        // Assert: 3 distinct type groups
+        result.AppointmentsByType.Should().HaveCount(3);
+
+        // The two tied types both appear with count 3, in the first two positions
+        var topTwo = result.AppointmentsByType.Take(2).ToList();
+        topTwo.Should().AllSatisfy(x => x.Count.Should().Be(3));
+        topTwo.Select(x => x.Type).Should().BeEquivalentTo(
+            new[] { AppointmentType.FollowUp.ToString(), AppointmentType.CheckIn.ToString() });
+
+        // InitialConsultation is the lowest-count type, placed last
+        result.AppointmentsByType[2].Type.Should().Be(AppointmentType.InitialConsultation.ToString());
+        result.AppointmentsByType[2].Count.Should().Be(1);
+    }
+
+    // ---------------------------------------------------------------------------
+    // ── GetPracticeSummaryAsync: Trend Bucketing ──
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_DailyBuckets_WhenRangeIs14DaysOrLess()
+    {
+        // Arrange: 7-day window with a single appointment on day 3.
+        var start = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end   = new DateTime(2025, 6, 8, 0, 0, 0, DateTimeKind.Utc); // 7 days
+
+        var client = new Client
+        {
+            FirstName = "Daily",
+            LastName  = "Bucket",
+            PrimaryNutritionistId = NutritionistId,
+            ConsentGiven = true,
+            EmailRemindersEnabled = false,
+            CreatedAt = start
+        };
+        _dbContext.Clients.Add(client);
+        _dbContext.SaveChanges();
+
+        _dbContext.Appointments.Add(MakeAppointment(
+            client.Id, AppointmentStatus.Completed, AppointmentType.CheckIn,
+            new DateTime(2025, 6, 3, 10, 0, 0, DateTimeKind.Utc)));
+        _dbContext.SaveChanges();
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(start, end);
+
+        // Assert: 7 daily buckets (Jun 1 through Jun 7)
+        result.TrendData.Should().HaveCount(7);
+
+        // Labels should follow "MMM d" pattern
+        result.TrendData[0].Label.Should().Be("Jun 1");
+        result.TrendData[6].Label.Should().Be("Jun 7");
+
+        // The single completed appointment lands in the Jun 3 bucket (index 2)
+        result.TrendData[2].Label.Should().Be("Jun 3");
+        result.TrendData[2].Visits.Should().Be(1);
+
+        // All other buckets should have zero visits
+        result.TrendData.Where(b => b.Label != "Jun 3").Should().AllSatisfy(b => b.Visits.Should().Be(0));
+    }
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_WeeklyBuckets_WhenRangeIs15To90Days()
+    {
+        // Arrange: the default 30-day window (WindowStart → WindowEnd) already seeds
+        // appointments; 30 days falls in the 15-90 day branch → weekly buckets.
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(WindowStart, WindowEnd);
+
+        // Assert: with a 30-day window the service creates weeks of 7 days each
+        // (4 full weeks + partial remainder = 5 buckets).
+        // Week labels follow "W{ISO week number}" pattern.
+        result.TrendData.Should().NotBeEmpty();
+        result.TrendData.Should().HaveCountGreaterThan(1,
+            because: "a 30-day range must produce multiple weekly buckets");
+
+        // Every label should start with "W" followed by digits
+        result.TrendData.Should().AllSatisfy(b =>
+            b.Label.Should().MatchRegex(@"^W\d+$",
+                because: "weekly bucket labels are ISO week numbers prefixed with 'W'"));
+
+        // Total visits across all buckets equals the total in the summary
+        result.TrendData.Sum(b => b.Visits).Should().Be(result.TotalVisits);
+    }
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_MonthlyBuckets_WhenRangeExceeds90Days()
+    {
+        // Arrange: 6-month window with appointments spread across different months.
+        var start = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end   = new DateTime(2025, 7, 1, 0, 0, 0, DateTimeKind.Utc); // 181 days
+
+        var client = new Client
+        {
+            FirstName = "Monthly",
+            LastName  = "Bucket",
+            PrimaryNutritionistId = NutritionistId,
+            ConsentGiven = true,
+            EmailRemindersEnabled = false,
+            CreatedAt = start
+        };
+        _dbContext.Clients.Add(client);
+        _dbContext.SaveChanges();
+
+        _dbContext.Appointments.AddRange(
+            MakeAppointment(client.Id, AppointmentStatus.Completed, AppointmentType.FollowUp,
+                new DateTime(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc)),
+            MakeAppointment(client.Id, AppointmentStatus.Completed, AppointmentType.FollowUp,
+                new DateTime(2025, 4, 10, 10, 0, 0, DateTimeKind.Utc)),
+            MakeAppointment(client.Id, AppointmentStatus.NoShow, AppointmentType.CheckIn,
+                new DateTime(2025, 6, 20, 9, 0, 0, DateTimeKind.Utc))
+        );
+        _dbContext.SaveChanges();
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(start, end);
+
+        // Assert: 6 monthly buckets (Jan through Jun)
+        result.TrendData.Should().HaveCount(6);
+        result.TrendData[0].Label.Should().Be("Jan 2025");
+        result.TrendData[5].Label.Should().Be("Jun 2025");
+
+        // January bucket has 1 visit
+        result.TrendData[0].Visits.Should().Be(1);
+
+        // April bucket (index 3) has 1 visit
+        result.TrendData[3].Visits.Should().Be(1);
+
+        // June bucket (index 5) has 1 no-show
+        result.TrendData[5].NoShows.Should().Be(1);
+    }
+
+    // ---------------------------------------------------------------------------
+    // ── GetPracticeSummaryAsync: Edge Cases ──
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_EmptyRange_ReturnsZerosAndEmptyCollections()
+    {
+        // Arrange: a window with no appointments and no clients created in it.
+        var emptyStart = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var emptyEnd   = new DateTime(2020, 1, 8, 0, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(emptyStart, emptyEnd);
+
+        // Assert
+        result.TotalVisits.Should().Be(0);
+        result.NewClients.Should().Be(0);
+        result.ReturningClients.Should().Be(0);
+        result.NoShowCount.Should().Be(0);
+        result.NoShowRate.Should().Be(0m);
+        result.CancellationCount.Should().Be(0);
+        result.CancellationRate.Should().Be(0m);
+        result.ActiveClients.Should().Be(0);
+        result.AppointmentsByType.Should().BeEmpty();
+        // 7 daily buckets for a 7-day range, all zeroed
+        result.TrendData.Should().HaveCount(7);
+        result.TrendData.Should().AllSatisfy(b =>
+        {
+            b.Visits.Should().Be(0);
+            b.NoShows.Should().Be(0);
+            b.Cancellations.Should().Be(0);
+        });
+    }
+
+    [Fact]
+    public async Task GetPracticeSummaryAsync_NoCompletedAppointments_ReturnsZeroReturningClients()
+    {
+        // Arrange: window with only NoShow and Cancelled appointments for a pre-existing client.
+        var start = new DateTime(2025, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end   = new DateTime(2025, 9, 8, 0, 0, 0, DateTimeKind.Utc);
+
+        // Use clientOld (created 2024-12-01, before this window) — if it had Completed
+        // appointments in this window it would be a returning client, but we deliberately
+        // only add non-Completed appointments.
+        _dbContext.Appointments.AddRange(
+            MakeAppointment(_clientOldId, AppointmentStatus.NoShow, AppointmentType.CheckIn,
+                new DateTime(2025, 9, 3, 10, 0, 0, DateTimeKind.Utc)),
+            MakeAppointment(_clientOldId, AppointmentStatus.Cancelled, AppointmentType.FollowUp,
+                new DateTime(2025, 9, 5, 10, 0, 0, DateTimeKind.Utc))
+        );
+        _dbContext.SaveChanges();
+
+        // Act
+        var result = await _sut.GetPracticeSummaryAsync(start, end);
+
+        // Assert
+        result.TotalVisits.Should().Be(0,
+            because: "no Completed appointments exist in this range");
+        result.ReturningClients.Should().Be(0,
+            because: "returning-client logic requires Completed appointments to identify client IDs");
+    }
+}


### PR DESCRIPTION
## Summary
- Add 14 unit tests for `CalendarService.GetAppointmentsByDateRangeAsync` covering date range filtering, 90-minute buffer logic, soft-delete exclusion, boundary conditions, and title formatting
- Add 12 unit tests for `ReportService.GetPracticeSummaryAsync` covering visit/client/no-show/cancellation aggregation, appointments-by-type grouping, and all three trend bucketing strategies (daily/weekly/monthly)
- All 26 tests pass against in-memory SQLite using existing `SharedConnectionContextFactory` pattern

Closes #290

## Test plan
- [x] All 26 new tests pass (`dotnet test --filter "CalendarServiceTests|ReportServiceTests"`)
- [x] Full test suite remains green (524 tests)
- [x] Follows existing test conventions (FluentAssertions, xUnit, SQLite, SharedConnectionContextFactory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)