### PR TITLE
test: add smoke tests for PDF/DOCX renderer classes

### DIFF
--- a/tests/Nutrir.Tests.Unit/Renderers/ConsentFormDocxRendererTests.cs
+++ b/tests/Nutrir.Tests.Unit/Renderers/ConsentFormDocxRendererTests.cs
@@ -1,0 +1,155 @@
+using FluentAssertions;
+using Nutrir.Core.Models;
+using Nutrir.Infrastructure.Services;
+using Xunit;
+
+namespace Nutrir.Tests.Unit.Renderers;
+
+public class ConsentFormDocxRendererTests
+{
+    // ---------------------------------------------------------------------------
+    // Render — fully populated content, no template (programmatic path)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithFullyPopulatedContentAndNoTemplate_ReturnsNonEmptyByteArray()
+    {
+        // Arrange
+        var content = new ConsentFormContent
+        {
+            Title = "Informed Consent for Nutritional Counselling",
+            PracticeName = "Healthy Horizons Nutrition",
+            FormVersion = "2.1",
+            ClientName = "Jane Doe",
+            PractitionerName = "Dr. Sarah Green, RD",
+            Date = new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+            SignatureBlockText = "By signing below I confirm I have read and understood the above.",
+            Sections =
+            [
+                new ConsentSection
+                {
+                    Heading = "Scope of Practice",
+                    Paragraphs =
+                    [
+                        "The practitioner will provide dietary guidance and meal planning.",
+                        "This does not constitute medical advice."
+                    ]
+                },
+                new ConsentSection
+                {
+                    Heading = "Privacy & Confidentiality",
+                    Paragraphs =
+                    [
+                        "All personal health information is kept strictly confidential.",
+                        "Data is stored securely and not shared with third parties without consent."
+                    ]
+                }
+            ]
+        };
+
+        // Act
+        var result = ConsentFormDocxRenderer.Render(content, templatePath: null);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "a fully-populated consent form should produce a valid DOCX document");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — minimal / sparse content, no template
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithMinimalContentAndNoTemplate_ReturnsNonEmptyByteArray()
+    {
+        // Arrange — empty sections list and blank string fields
+        var content = new ConsentFormContent
+        {
+            Title = string.Empty,
+            PracticeName = string.Empty,
+            FormVersion = string.Empty,
+            ClientName = string.Empty,
+            PractitionerName = string.Empty,
+            Date = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            SignatureBlockText = string.Empty,
+            Sections = []
+        };
+
+        // Act
+        var result = ConsentFormDocxRenderer.Render(content, templatePath: null);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "rendering with empty content should still produce a valid DOCX structure");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — non-existent template path falls back to programmatic generation
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithNonExistentTemplatePath_FallsBackToProgrammaticAndReturnsNonEmptyByteArray()
+    {
+        // Arrange — provide a path that does not exist so the renderer falls back
+        var content = new ConsentFormContent
+        {
+            Title = "Consent Form",
+            PracticeName = "Test Practice",
+            FormVersion = "1.0",
+            ClientName = "John Smith",
+            PractitionerName = "Dr. Alice Brown",
+            Date = new DateTime(2024, 3, 20, 0, 0, 0, DateTimeKind.Utc),
+            SignatureBlockText = "I agree to the terms above.",
+            Sections =
+            [
+                new ConsentSection
+                {
+                    Heading = "Terms",
+                    Paragraphs = ["I understand and agree to the terms described herein."]
+                }
+            ]
+        };
+
+        // Act
+        var result = ConsentFormDocxRenderer.Render(content, templatePath: "/tmp/nonexistent-template.docx");
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "when the template file does not exist the renderer falls back to programmatic generation");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — sections with empty paragraph list
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithSectionsHavingNoParagraphs_ReturnsNonEmptyByteArray()
+    {
+        // Arrange
+        var content = new ConsentFormContent
+        {
+            Title = "Consent Form",
+            PracticeName = "Nutrition Co.",
+            FormVersion = "1.0",
+            ClientName = "Mary Watson",
+            PractitionerName = "Dr. Tom Hill",
+            Date = new DateTime(2024, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            SignatureBlockText = "Signature required below.",
+            Sections =
+            [
+                new ConsentSection
+                {
+                    Heading = "Heading With No Body",
+                    Paragraphs = []
+                }
+            ]
+        };
+
+        // Act
+        var result = ConsentFormDocxRenderer.Render(content, templatePath: null);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "a section without paragraphs should still render successfully");
+    }
+}

--- a/tests/Nutrir.Tests.Unit/Renderers/ConsentFormPdfRendererTests.cs
+++ b/tests/Nutrir.Tests.Unit/Renderers/ConsentFormPdfRendererTests.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using Nutrir.Core.Models;
+using Nutrir.Infrastructure.Services;
+using QuestPDF.Infrastructure;
+using Xunit;
+
+namespace Nutrir.Tests.Unit.Renderers;
+
+public class ConsentFormPdfRendererTests
+{
+    public ConsentFormPdfRendererTests()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — fully populated content
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithFullyPopulatedContent_ReturnsNonEmptyByteArray()
+    {
+        // Arrange
+        var content = new ConsentFormContent
+        {
+            Title = "Informed Consent for Nutritional Counselling",
+            PracticeName = "Healthy Horizons Nutrition",
+            FormVersion = "2.1",
+            ClientName = "Jane Doe",
+            PractitionerName = "Dr. Sarah Green, RD",
+            Date = new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+            SignatureBlockText = "By signing below I confirm I have read and understood the above.",
+            Sections =
+            [
+                new ConsentSection
+                {
+                    Heading = "Scope of Practice",
+                    Paragraphs =
+                    [
+                        "The practitioner will provide dietary guidance and meal planning.",
+                        "This does not constitute medical advice."
+                    ]
+                },
+                new ConsentSection
+                {
+                    Heading = "Privacy & Confidentiality",
+                    Paragraphs =
+                    [
+                        "All personal health information is kept strictly confidential.",
+                        "Data is stored securely and not shared with third parties without consent."
+                    ]
+                }
+            ]
+        };
+
+        // Act
+        var result = ConsentFormPdfRenderer.Render(content);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "a fully-populated consent form should produce a valid PDF");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — minimal / sparse content
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithMinimalContent_ReturnsNonEmptyByteArray()
+    {
+        // Arrange — empty sections list and blank optional strings
+        var content = new ConsentFormContent
+        {
+            Title = string.Empty,
+            PracticeName = string.Empty,
+            FormVersion = string.Empty,
+            ClientName = string.Empty,
+            PractitionerName = string.Empty,
+            Date = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            SignatureBlockText = string.Empty,
+            Sections = []
+        };
+
+        // Act
+        var result = ConsentFormPdfRenderer.Render(content);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "rendering with empty content should still produce a valid PDF structure");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — sections with empty paragraph list
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithSectionsHavingNoParagraphs_ReturnsNonEmptyByteArray()
+    {
+        // Arrange
+        var content = new ConsentFormContent
+        {
+            Title = "Consent Form",
+            PracticeName = "Test Practice",
+            FormVersion = "1.0",
+            ClientName = "John Smith",
+            PractitionerName = "Dr. Alice Brown",
+            Date = new DateTime(2024, 3, 20, 0, 0, 0, DateTimeKind.Utc),
+            SignatureBlockText = "I agree to the terms above.",
+            Sections =
+            [
+                new ConsentSection
+                {
+                    Heading = "Terms",
+                    Paragraphs = []
+                }
+            ]
+        };
+
+        // Act
+        var result = ConsentFormPdfRenderer.Render(content);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "a section with no paragraphs should still render correctly");
+    }
+}

--- a/tests/Nutrir.Tests.Unit/Renderers/DataExportPdfRendererTests.cs
+++ b/tests/Nutrir.Tests.Unit/Renderers/DataExportPdfRendererTests.cs
@@ -1,0 +1,349 @@
+using FluentAssertions;
+using Nutrir.Core.DTOs;
+using Nutrir.Infrastructure.Services;
+using QuestPDF.Infrastructure;
+using Xunit;
+
+namespace Nutrir.Tests.Unit.Renderers;
+
+public class DataExportPdfRendererTests
+{
+    public DataExportPdfRendererTests()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers — build test DTOs
+    // ---------------------------------------------------------------------------
+
+    private static ExportMetadataDto BuildMetadata() => new(
+        ExportDate: new DateTime(2024, 9, 15, 12, 0, 0, DateTimeKind.Utc),
+        ExportVersion: "1.0",
+        ExportFormat: "pdf",
+        ClientId: 42,
+        GeneratedByName: "Dr. Sarah Green, RD",
+        PipedaNotice: "This export is provided in compliance with PIPEDA.");
+
+    private static ClientProfileExportDto BuildClientProfile() => new(
+        FirstName: "Jane",
+        LastName: "Doe",
+        Email: "jane.doe@example.com",
+        Phone: "555-0100",
+        DateOfBirth: new DateOnly(1985, 4, 20),
+        Notes: "Long-term client, excellent compliance.",
+        ConsentGiven: true,
+        ConsentTimestamp: new DateTime(2023, 1, 10, 9, 0, 0, DateTimeKind.Utc),
+        ConsentPolicyVersion: "1.0",
+        PrimaryNutritionistName: "Dr. Sarah Green, RD",
+        IsDeleted: false,
+        CreatedAt: new DateTime(2023, 1, 10, 9, 0, 0, DateTimeKind.Utc),
+        UpdatedAt: new DateTime(2024, 3, 5, 11, 0, 0, DateTimeKind.Utc),
+        DeletedAt: null);
+
+    private static HealthProfileExportDto BuildHealthProfile() => new(
+        Allergies:
+        [
+            new AllergyExportDto("Peanuts", "Moderate", "Food", IsDeleted: false, DeletedAt: null)
+        ],
+        Medications:
+        [
+            new MedicationExportDto("Vitamin D", "1000 IU", "Daily", "Bone health", IsDeleted: false, DeletedAt: null)
+        ],
+        Conditions:
+        [
+            new ConditionExportDto("Type 2 Diabetes", "E11", new DateOnly(2020, 6, 1), "Active", "Well controlled", IsDeleted: false, DeletedAt: null)
+        ],
+        DietaryRestrictions:
+        [
+            new DietaryRestrictionExportDto("GlutenFree", "Coeliac disease", IsDeleted: false, DeletedAt: null)
+        ]);
+
+    private static List<AppointmentExportDto> BuildAppointments() =>
+    [
+        new AppointmentExportDto(
+            Type: "InitialConsultation",
+            Status: "Completed",
+            StartTime: new DateTime(2023, 2, 14, 10, 0, 0, DateTimeKind.Utc),
+            DurationMinutes: 60,
+            Location: "InPerson",
+            LocationNotes: "Main office",
+            Notes: "Went well.",
+            NutritionistName: "Dr. Sarah Green, RD",
+            CancellationReason: null,
+            CancelledAt: null,
+            IsDeleted: false,
+            DeletedAt: null,
+            CreatedAt: new DateTime(2023, 2, 1, 9, 0, 0, DateTimeKind.Utc))
+    ];
+
+    private static List<MealPlanExportDto> BuildMealPlans() =>
+    [
+        new MealPlanExportDto(
+            Title: "Spring Reset Plan",
+            Description: "A clean-eating plan for spring.",
+            Status: "Active",
+            StartDate: new DateOnly(2024, 3, 1),
+            EndDate: new DateOnly(2024, 3, 7),
+            CalorieTarget: 1800m,
+            ProteinTargetG: 130m,
+            CarbsTargetG: 200m,
+            FatTargetG: 60m,
+            Notes: "Practitioner notes.",
+            Instructions: "Drink 2L of water daily.",
+            CreatedByName: "Dr. Sarah Green, RD",
+            Days:
+            [
+                new MealPlanDayExportDto(
+                    DayNumber: 1,
+                    Label: "Monday",
+                    Notes: null,
+                    MealSlots:
+                    [
+                        new MealSlotExportDto(
+                            MealType: "Breakfast",
+                            CustomName: null,
+                            Notes: null,
+                            Items:
+                            [
+                                new MealItemExportDto("Oatmeal", 1m, "cup", 320m, 12m, 55m, 6m, null)
+                            ])
+                    ])
+            ],
+            IsDeleted: false,
+            DeletedAt: null,
+            CreatedAt: new DateTime(2024, 2, 25, 10, 0, 0, DateTimeKind.Utc))
+    ];
+
+    private static List<ProgressGoalExportDto> BuildProgressGoals() =>
+    [
+        new ProgressGoalExportDto(
+            Title: "Lose 10 lbs",
+            Description: "Gradual weight loss over 3 months.",
+            GoalType: "Weight",
+            TargetValue: 165m,
+            TargetUnit: "lbs",
+            TargetDate: new DateOnly(2024, 6, 1),
+            Status: "Active",
+            CreatedByName: "Dr. Sarah Green, RD",
+            IsDeleted: false,
+            DeletedAt: null,
+            CreatedAt: new DateTime(2024, 1, 15, 9, 0, 0, DateTimeKind.Utc))
+    ];
+
+    private static List<ProgressEntryExportDto> BuildProgressEntries() =>
+    [
+        new ProgressEntryExportDto(
+            EntryDate: new DateOnly(2024, 4, 10),
+            Notes: "Feeling great this week.",
+            CreatedByName: "Dr. Sarah Green, RD",
+            Measurements:
+            [
+                new ProgressMeasurementExportDto("Weight", null, 175m, "lbs"),
+                new ProgressMeasurementExportDto("BloodPressureSystolic", null, 118m, "mmHg")
+            ],
+            IsDeleted: false,
+            DeletedAt: null,
+            CreatedAt: new DateTime(2024, 4, 10, 14, 0, 0, DateTimeKind.Utc))
+    ];
+
+    private static List<IntakeFormExportDto> BuildIntakeForms() =>
+    [
+        new IntakeFormExportDto(
+            Status: "Submitted",
+            SubmittedAt: new DateTime(2023, 1, 5, 11, 0, 0, DateTimeKind.Utc),
+            ReviewedAt: new DateTime(2023, 1, 8, 10, 0, 0, DateTimeKind.Utc),
+            ReviewedByName: "Dr. Sarah Green, RD",
+            CreatedByName: "System",
+            Responses:
+            [
+                new IntakeFormResponseExportDto("personal", "occupation", "Teacher"),
+                new IntakeFormResponseExportDto("health", "current_weight", "185")
+            ],
+            IsDeleted: false,
+            DeletedAt: null,
+            CreatedAt: new DateTime(2023, 1, 3, 8, 0, 0, DateTimeKind.Utc))
+    ];
+
+    private static ConsentHistoryExportDto BuildConsentHistory() => new(
+        Events:
+        [
+            new ConsentEventExportDto(
+                EventType: "ConsentGiven",
+                ConsentPurpose: "Nutritional counselling",
+                PolicyVersion: "1.0",
+                Timestamp: new DateTime(2023, 1, 10, 9, 0, 0, DateTimeKind.Utc),
+                RecordedByName: "Dr. Sarah Green, RD",
+                Notes: null)
+        ],
+        Forms:
+        [
+            new ConsentFormExportDto(
+                FormVersion: "1.0",
+                GeneratedAt: new DateTime(2023, 1, 10, 8, 30, 0, DateTimeKind.Utc),
+                GeneratedByName: "Dr. Sarah Green, RD",
+                SignatureMethod: "Digital",
+                IsSigned: true,
+                SignedAt: new DateTime(2023, 1, 10, 9, 5, 0, DateTimeKind.Utc),
+                SignedByName: "Jane Doe",
+                Notes: null,
+                CreatedAt: new DateTime(2023, 1, 10, 8, 30, 0, DateTimeKind.Utc))
+        ]);
+
+    private static List<AuditLogExportDto> BuildAuditLog() =>
+    [
+        new AuditLogExportDto(
+            Timestamp: new DateTime(2023, 1, 10, 9, 0, 0, DateTimeKind.Utc),
+            Action: "ClientCreated",
+            EntityType: "Client",
+            EntityId: "42",
+            Details: "Initial client record created",
+            Source: "Web"),
+        new AuditLogExportDto(
+            Timestamp: new DateTime(2024, 9, 15, 12, 0, 0, DateTimeKind.Utc),
+            Action: "ClientDataExported",
+            EntityType: "Client",
+            EntityId: "42",
+            Details: "Exported as PDF",
+            Source: "Web")
+    ];
+
+    // ---------------------------------------------------------------------------
+    // Render — fully populated export DTO
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithFullyPopulatedData_ReturnsNonEmptyByteArray()
+    {
+        // Arrange
+        var data = new ClientDataExportDto(
+            ExportMetadata: BuildMetadata(),
+            ClientProfile: BuildClientProfile(),
+            HealthProfile: BuildHealthProfile(),
+            Appointments: BuildAppointments(),
+            MealPlans: BuildMealPlans(),
+            ProgressGoals: BuildProgressGoals(),
+            ProgressEntries: BuildProgressEntries(),
+            IntakeForms: BuildIntakeForms(),
+            ConsentHistory: BuildConsentHistory(),
+            AuditLog: BuildAuditLog());
+
+        // Act
+        var result = DataExportPdfRenderer.Render(data);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "a fully-populated client data export should produce a valid PDF");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — minimal / sparse export DTO (empty collections, no optional fields)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithMinimalData_ReturnsNonEmptyByteArray()
+    {
+        // Arrange — all collection properties are empty; optional fields are null
+        var data = new ClientDataExportDto(
+            ExportMetadata: new ExportMetadataDto(
+                ExportDate: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                ExportVersion: "1.0",
+                ExportFormat: "pdf",
+                ClientId: 1,
+                GeneratedByName: "System",
+                PipedaNotice: "PIPEDA notice."),
+            ClientProfile: new ClientProfileExportDto(
+                FirstName: "Test",
+                LastName: "Client",
+                Email: null,
+                Phone: null,
+                DateOfBirth: null,
+                Notes: null,
+                ConsentGiven: false,
+                ConsentTimestamp: null,
+                ConsentPolicyVersion: null,
+                PrimaryNutritionistName: "Unknown",
+                IsDeleted: false,
+                CreatedAt: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                UpdatedAt: null,
+                DeletedAt: null),
+            HealthProfile: new HealthProfileExportDto(
+                Allergies: [],
+                Medications: [],
+                Conditions: [],
+                DietaryRestrictions: []),
+            Appointments: [],
+            MealPlans: [],
+            ProgressGoals: [],
+            ProgressEntries: [],
+            IntakeForms: [],
+            ConsentHistory: new ConsentHistoryExportDto(Events: [], Forms: []),
+            AuditLog: []);
+
+        // Act
+        var result = DataExportPdfRenderer.Render(data);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "a sparse export with empty collections should still produce a valid PDF structure");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — meal plan with nested day/slot/item hierarchy
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithMealPlanHierarchy_ReturnsNonEmptyByteArray()
+    {
+        // Arrange — focus on a multi-day plan with multiple slots and items
+        var data = new ClientDataExportDto(
+            ExportMetadata: BuildMetadata(),
+            ClientProfile: BuildClientProfile(),
+            HealthProfile: new HealthProfileExportDto([], [], [], []),
+            Appointments: [],
+            MealPlans:
+            [
+                new MealPlanExportDto(
+                    Title: "Complex Plan",
+                    Description: null,
+                    Status: "Draft",
+                    StartDate: null,
+                    EndDate: null,
+                    CalorieTarget: null,
+                    ProteinTargetG: null,
+                    CarbsTargetG: null,
+                    FatTargetG: null,
+                    Notes: null,
+                    Instructions: null,
+                    CreatedByName: "Nutritionist",
+                    Days:
+                    [
+                        new MealPlanDayExportDto(1, "Day 1", null,
+                        [
+                            new MealSlotExportDto("Breakfast", null, null,
+                            [
+                                new MealItemExportDto("Eggs", 2m, "large", 156m, 12m, 1m, 11m, null),
+                                new MealItemExportDto("Toast", 1m, "slice", 79m, 3m, 15m, 1m, "Whole grain")
+                            ]),
+                            new MealSlotExportDto("Lunch", null, null, [])
+                        ]),
+                        new MealPlanDayExportDto(2, null, null, [])
+                    ],
+                    IsDeleted: false,
+                    DeletedAt: null,
+                    CreatedAt: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            ],
+            ProgressGoals: [],
+            ProgressEntries: [],
+            IntakeForms: [],
+            ConsentHistory: new ConsentHistoryExportDto([], []),
+            AuditLog: []);
+
+        // Act
+        var result = DataExportPdfRenderer.Render(data);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "a meal plan export with nested day/slot/item hierarchy should render successfully");
+    }
+}

--- a/tests/Nutrir.Tests.Unit/Renderers/MealPlanPdfRendererTests.cs
+++ b/tests/Nutrir.Tests.Unit/Renderers/MealPlanPdfRendererTests.cs
@@ -1,0 +1,278 @@
+using FluentAssertions;
+using Nutrir.Core.DTOs;
+using Nutrir.Core.Enums;
+using Nutrir.Infrastructure.Services;
+using QuestPDF.Infrastructure;
+using Xunit;
+
+namespace Nutrir.Tests.Unit.Renderers;
+
+public class MealPlanPdfRendererTests
+{
+    public MealPlanPdfRendererTests()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — fully populated plan with days, slots, and items
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithFullyPopulatedPlan_ReturnsNonEmptyByteArray()
+    {
+        // Arrange
+        var plan = new MealPlanDetailDto(
+            Id: 1,
+            Title: "7-Day Weight Loss Plan",
+            Description: "A structured plan designed to support healthy weight loss.",
+            Status: MealPlanStatus.Active,
+            ClientId: 42,
+            ClientFirstName: "Jane",
+            ClientLastName: "Doe",
+            CreatedByUserId: "user-001",
+            CreatedByName: "Dr. Sarah Green, RD",
+            StartDate: new DateOnly(2024, 6, 3),
+            EndDate: new DateOnly(2024, 6, 9),
+            CalorieTarget: 1800m,
+            ProteinTargetG: 130m,
+            CarbsTargetG: 200m,
+            FatTargetG: 60m,
+            Notes: "Internal notes for the practitioner.",
+            Instructions: "Eat every 3-4 hours and stay well hydrated.",
+            Days:
+            [
+                new MealPlanDayDto(
+                    Id: 1,
+                    DayNumber: 1,
+                    Label: "Monday",
+                    Notes: "Focus on high-protein breakfast.",
+                    MealSlots:
+                    [
+                        new MealSlotDto(
+                            Id: 1,
+                            MealType: MealType.Breakfast,
+                            CustomName: null,
+                            SortOrder: 0,
+                            Notes: null,
+                            Items:
+                            [
+                                new MealItemDto(
+                                    Id: 1,
+                                    FoodName: "Oatmeal with berries",
+                                    Quantity: 1m,
+                                    Unit: "cup",
+                                    CaloriesKcal: 320m,
+                                    ProteinG: 12m,
+                                    CarbsG: 55m,
+                                    FatG: 6m,
+                                    Notes: "Use rolled oats",
+                                    SortOrder: 0),
+                                new MealItemDto(
+                                    Id: 2,
+                                    FoodName: "Greek Yogurt",
+                                    Quantity: 150m,
+                                    Unit: "g",
+                                    CaloriesKcal: 100m,
+                                    ProteinG: 17m,
+                                    CarbsG: 6m,
+                                    FatG: 0m,
+                                    Notes: null,
+                                    SortOrder: 1)
+                            ],
+                            TotalCalories: 420m,
+                            TotalProtein: 29m,
+                            TotalCarbs: 61m,
+                            TotalFat: 6m),
+                        new MealSlotDto(
+                            Id: 2,
+                            MealType: MealType.Lunch,
+                            CustomName: null,
+                            SortOrder: 1,
+                            Notes: "Largest meal of the day.",
+                            Items:
+                            [
+                                new MealItemDto(
+                                    Id: 3,
+                                    FoodName: "Grilled Chicken Breast",
+                                    Quantity: 150m,
+                                    Unit: "g",
+                                    CaloriesKcal: 248m,
+                                    ProteinG: 47m,
+                                    CarbsG: 0m,
+                                    FatG: 5m,
+                                    Notes: null,
+                                    SortOrder: 0)
+                            ],
+                            TotalCalories: 248m,
+                            TotalProtein: 47m,
+                            TotalCarbs: 0m,
+                            TotalFat: 5m)
+                    ],
+                    TotalCalories: 668m,
+                    TotalProtein: 76m,
+                    TotalCarbs: 61m,
+                    TotalFat: 11m)
+            ],
+            CreatedAt: new DateTime(2024, 5, 28, 10, 0, 0, DateTimeKind.Utc),
+            UpdatedAt: new DateTime(2024, 5, 30, 14, 0, 0, DateTimeKind.Utc));
+
+        // Act
+        var result = MealPlanPdfRenderer.Render(plan);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "a fully-populated meal plan should produce a valid PDF");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — minimal / sparse plan (no days, no optional fields)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithMinimalPlan_ReturnsNonEmptyByteArray()
+    {
+        // Arrange — only required fields populated, no days or optional text
+        var plan = new MealPlanDetailDto(
+            Id: 2,
+            Title: "Minimal Plan",
+            Description: null,
+            Status: MealPlanStatus.Draft,
+            ClientId: 5,
+            ClientFirstName: "Bob",
+            ClientLastName: "Smith",
+            CreatedByUserId: "user-002",
+            CreatedByName: null,
+            StartDate: null,
+            EndDate: null,
+            CalorieTarget: null,
+            ProteinTargetG: null,
+            CarbsTargetG: null,
+            FatTargetG: null,
+            Notes: null,
+            Instructions: null,
+            Days: [],
+            CreatedAt: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            UpdatedAt: null);
+
+        // Act
+        var result = MealPlanPdfRenderer.Render(plan);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "a plan with no days or optional data should still produce a valid PDF");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — day with no meal slots
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithDayHavingNoMealSlots_ReturnsNonEmptyByteArray()
+    {
+        // Arrange
+        var plan = new MealPlanDetailDto(
+            Id: 3,
+            Title: "Empty Day Plan",
+            Description: "A plan where a day has no meal slots yet.",
+            Status: MealPlanStatus.Draft,
+            ClientId: 7,
+            ClientFirstName: "Alice",
+            ClientLastName: "Chen",
+            CreatedByUserId: "user-003",
+            CreatedByName: "Nutritionist A",
+            StartDate: new DateOnly(2024, 8, 1),
+            EndDate: new DateOnly(2024, 8, 7),
+            CalorieTarget: 2000m,
+            ProteinTargetG: null,
+            CarbsTargetG: null,
+            FatTargetG: null,
+            Notes: null,
+            Instructions: null,
+            Days:
+            [
+                new MealPlanDayDto(
+                    Id: 10,
+                    DayNumber: 1,
+                    Label: null,
+                    Notes: null,
+                    MealSlots: [],
+                    TotalCalories: 0m,
+                    TotalProtein: 0m,
+                    TotalCarbs: 0m,
+                    TotalFat: 0m)
+            ],
+            CreatedAt: new DateTime(2024, 7, 25, 0, 0, 0, DateTimeKind.Utc),
+            UpdatedAt: null);
+
+        // Act
+        var result = MealPlanPdfRenderer.Render(plan);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "a day with no meal slots should render the 'No meals added' fallback without throwing");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render — slot with no items (empty table)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Render_WithSlotHavingNoItems_ReturnsNonEmptyByteArray()
+    {
+        // Arrange
+        var plan = new MealPlanDetailDto(
+            Id: 4,
+            Title: "Empty Slot Plan",
+            Description: null,
+            Status: MealPlanStatus.Active,
+            ClientId: 9,
+            ClientFirstName: "Carol",
+            ClientLastName: "Taylor",
+            CreatedByUserId: "user-004",
+            CreatedByName: "Nutritionist B",
+            StartDate: null,
+            EndDate: null,
+            CalorieTarget: null,
+            ProteinTargetG: null,
+            CarbsTargetG: null,
+            FatTargetG: null,
+            Notes: null,
+            Instructions: null,
+            Days:
+            [
+                new MealPlanDayDto(
+                    Id: 20,
+                    DayNumber: 1,
+                    Label: "Day 1",
+                    Notes: null,
+                    MealSlots:
+                    [
+                        new MealSlotDto(
+                            Id: 5,
+                            MealType: MealType.Dinner,
+                            CustomName: "Evening Meal",
+                            SortOrder: 0,
+                            Notes: null,
+                            Items: [],
+                            TotalCalories: 0m,
+                            TotalProtein: 0m,
+                            TotalCarbs: 0m,
+                            TotalFat: 0m)
+                    ],
+                    TotalCalories: 0m,
+                    TotalProtein: 0m,
+                    TotalCarbs: 0m,
+                    TotalFat: 0m)
+            ],
+            CreatedAt: new DateTime(2024, 4, 10, 0, 0, 0, DateTimeKind.Utc),
+            UpdatedAt: null);
+
+        // Act
+        var result = MealPlanPdfRenderer.Render(plan);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty(because: "a meal slot with no items should render the slot header without throwing");
+    }
+}


### PR DESCRIPTION
## Summary
- Add 14 smoke tests across 4 renderer classes (`ConsentFormPdfRenderer`, `ConsentFormDocxRenderer`, `MealPlanPdfRenderer`, `DataExportPdfRenderer`)
- Tests verify renderers produce non-empty byte arrays without throwing for both fully-populated and minimal/sparse input data
- Covers edge cases: empty sections, empty paragraphs, no meal slots/items, non-existent DOCX template path fallback

## Test plan
- [x] All 14 tests pass locally (`dotnet test --filter Renderers`)
- [x] Code review: fixed static constructor → instance constructor for QuestPDF license init to avoid parallel test flakiness

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)